### PR TITLE
Read fault return value is made a global root.

### DIFF
--- a/byterun/caml/domain_state.tbl
+++ b/byterun/caml/domain_state.tbl
@@ -1,31 +1,88 @@
 DOMAIN_STATE(volatile uintnat, young_limit)
+/* Minor heap limit. Typically young_limit == young_end, but this field is set
+ * by other domains to signal this domain by causing a spurious allocation
+ * failure. */
+
 DOMAIN_STATE(char*, young_ptr)
+/* Minor heap pointer */
+
 DOMAIN_STATE(char*, young_start)
+/* Start of the minor heap */
+
 DOMAIN_STATE(char*, young_end)
+/* End of the minor heap. always(young_end <= young_ptr <= young_start) */
+
 DOMAIN_STATE(struct stack_info*, current_stack)
-DOMAIN_STATE(void*, exn_handler) /* points into current stack */
+/* Current stack */
+
+DOMAIN_STATE(void*, exn_handler)
+/* Pointer into into the current stack */
+
 DOMAIN_STATE(value*, gc_regs_buckets)
+
 DOMAIN_STATE(struct c_stack_link*, c_stack)
+/* The C stack associated with this domain. Used by this domain to perform external calls. */
+
 DOMAIN_STATE(value**, gc_regs_slot)
+
 DOMAIN_STATE(struct caml_minor_tables*, minor_tables)
+
 DOMAIN_STATE(struct mark_stack*, mark_stack)
+/* Mark stack */
+
 DOMAIN_STATE(uintnat, marking_done)
+/* Is marking done for the current major cycle. */
+
 DOMAIN_STATE(uintnat, sweeping_done)
+/* Is sweeping done for the current major cycle. */
+
 DOMAIN_STATE(uintnat, stealing)
+
 DOMAIN_STATE(uintnat, allocated_words)
+
 DOMAIN_STATE(uintnat, swept_words)
+
 DOMAIN_STATE(struct caml__roots_block*, local_roots)
+
 DOMAIN_STATE(struct caml_ephe_info*, ephe_info)
+
 DOMAIN_STATE(struct caml_final_info*, final_info)
+
 DOMAIN_STATE(intnat, backtrace_pos)
+
 DOMAIN_STATE(intnat, backtrace_active)
+
 DOMAIN_STATE(code_t*, backtrace_buffer)
+
 DOMAIN_STATE(caml_root, backtrace_last_exn)
+
 DOMAIN_STATE(intnat, compare_unordered)
+
 DOMAIN_STATE(uintnat, oo_next_id_local)
+
 DOMAIN_STATE(uintnat, force_major_slice)
 
+DOMAIN_STATE(caml_root, read_fault_ret_val)
+/* Global root for return value of a read fault */
+
+DOMAIN_STATE(intnat, critical_section_nesting)
+
+DOMAIN_STATE(struct interrupt*, pending_interrupts)
+
+DOMAIN_STATE(int, parser_trace)
+/* See parsing.c */
+
+DOMAIN_STATE(asize_t, minor_heap_wsz)
+
+DOMAIN_STATE(struct caml_heap_state*, shared_heap)
+
+DOMAIN_STATE(int, id)
+
+DOMAIN_STATE(int, unique_id)
+
+/*****************************************************************************/
 /* GC stats (see gc_ctrl.c and the Gc module) */
+/*****************************************************************************/
 DOMAIN_STATE(uintnat, stat_minor_words)
 DOMAIN_STATE(uintnat, stat_promoted_words)
 DOMAIN_STATE(uintnat, stat_major_words)
@@ -33,19 +90,9 @@ DOMAIN_STATE(intnat, stat_minor_collections)
 DOMAIN_STATE(intnat, stat_major_collections)
 DOMAIN_STATE(uintnat, stat_blocks_marked)
 
-DOMAIN_STATE(intnat, critical_section_nesting)
-DOMAIN_STATE(struct interrupt*, pending_interrupts)
-
-/* See parsing.c */
-DOMAIN_STATE(int, parser_trace)
-
-DOMAIN_STATE(asize_t, minor_heap_wsz)
-
-DOMAIN_STATE(struct caml_heap_state*, shared_heap)
-DOMAIN_STATE(int, id)
-DOMAIN_STATE(int, unique_id)
-
+/*****************************************************************************/
 /* Detailed stats */
+/*****************************************************************************/
 DOMAIN_STATE(uintnat, allocations)
 DOMAIN_STATE(uintnat, mutable_loads)
 DOMAIN_STATE(uintnat, immutable_loads)

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -226,6 +226,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     caml_init_major_gc(domain_state);
     caml_reallocate_minor_heap(initial_minor_heap_wsize);
     Caml_state->current_stack = caml_alloc_main_stack (Stack_size/sizeof(value));
+    Caml_state->read_fault_ret_val = caml_create_root(Val_unit);
 
     domain_state->backtrace_buffer = NULL;
 #ifndef NATIVE_CODE
@@ -873,6 +874,7 @@ static void domain_terminate()
     caml_plat_unlock(&s->lock);
   }
 
+  caml_delete_root(domain_state->read_fault_ret_val);
   caml_stat_free(domain_state->final_info);
   caml_teardown_major_gc();
   caml_teardown_shared_heap(domain_state->shared_heap);

--- a/byterun/globroots.c
+++ b/byterun/globroots.c
@@ -192,6 +192,8 @@ static void scan_native_globals(scanning_action f, void* fdata)
 #endif
 
 void caml_scan_global_roots(scanning_action f, void* fdata) {
+  /* FIXME KC: Needs to be done only once per major cycle. Currently, every
+   * domain scans global roots */
   scan_global_roots(f, fdata);
 #ifdef NATIVE_CODE
   scan_native_globals(f, fdata);


### PR DESCRIPTION
Read fault return value field used to be a local root. It certainly needs to be a root since a GC may occur after the return value field is set. But the return value field is written to by a different domain different from the domain issuing the read fault request. The domain issuing the read fault request has the return value field in its local root set. This introduces a data race between the remote domain writing the return value of a read fault to the field and a minor GC (specifically, `oldify_one`) in the read fault issuing domain writing the default value (`Val_unit`) to the field. The race may overwrite the result written by the remote domain.

The fix is to make the read fault return value field a global root, which is only scanned when all the domains are blocked at the beginning of the major cycle, which removes the race. The commit creates one global root per domain for the read fault return value field; there can be only one outstanding read fault request per domain.