### PR TITLE
fix segfault in major_gc. Fixes #247

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -514,8 +514,8 @@ static intnat do_some_marking(struct mark_stack* stk, intnat budget) {
         if (Tag_hd(hd) == Cont_tag) {
           mark_stack_push(stk, e);
           caml_darken_cont(v);
-          e = stk->stack[--stk->count];
-        } else {
+	  e = (mark_entry){0};
+	} else {
 again:
           if (Tag_hd(hd) == Lazy_tag) {
             if (!atomic_compare_exchange_strong(


### PR DESCRIPTION
Tested this branch against the `queens_segfault` branch on sandmark and no longer see the segfault.