### PR TITLE
Inlining loads in the native code

### DIFF
--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -38,13 +38,13 @@ let rec with_afl_logging b =
     let cur_pos = Ident.create "pos" in
     let afl_area = Ident.create "shared_mem" in
     let op oper args = Cop (oper, args, Debuginfo.none) in
-    Clet(afl_area, op (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}) [afl_area_ptr],
-    Clet(cur_pos,  op Cxor [op (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true})
+    Clet(afl_area, op (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}) [afl_area_ptr],
+    Clet(cur_pos,  op Cxor [op (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false})
       [afl_prev_loc]; Cconst_int cur_location],
     Csequence(
       op (Cstore(Byte_unsigned, Assignment))
          [op Cadda [Cvar afl_area; Cvar cur_pos];
-          op Cadda [op (Cload {memory_chunk=Byte_unsigned; mutability=Asttypes.Mutable; is_atomic=true})
+          op Cadda [op (Cload {memory_chunk=Byte_unsigned; mutability=Asttypes.Mutable; is_atomic=false})
                        [op Cadda [Cvar afl_area; Cvar cur_pos]];
                     Cconst_int 1]],
       op (Cstore(Word_int, Assignment))

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -38,13 +38,13 @@ let rec with_afl_logging b =
     let cur_pos = Ident.create "pos" in
     let afl_area = Ident.create "shared_mem" in
     let op oper args = Cop (oper, args, Debuginfo.none) in
-    Clet(afl_area, op (Cload (Word_int, Asttypes.Mutable)) [afl_area_ptr],
-    Clet(cur_pos,  op Cxor [op (Cload (Word_int, Asttypes.Mutable))
+    Clet(afl_area, op (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}) [afl_area_ptr],
+    Clet(cur_pos,  op Cxor [op (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true})
       [afl_prev_loc]; Cconst_int cur_location],
     Csequence(
       op (Cstore(Byte_unsigned, Assignment))
          [op Cadda [Cvar afl_area; Cvar cur_pos];
-          op Cadda [op (Cload (Byte_unsigned, Asttypes.Mutable))
+          op Cadda [op (Cload {memory_chunk=Byte_unsigned; mutability=Asttypes.Mutable; is_atomic=true})
                        [op Cadda [Cvar afl_area; Cvar cur_pos]];
                     Cconst_int 1]],
       op (Cstore(Word_int, Assignment))

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -203,7 +203,7 @@ method! select_operation op args dbg =
       self#select_floatarith false Idivf Ifloatdiv args
   | Cextcall("sqrt", _, false, _) ->
      begin match args with
-       [Cop(Cload ((Double|Double_u as chunk), _), [loc], _dbg)] ->
+       [Cop(Cload {memory_chunk=(Double|Double_u as chunk)}, [loc], _dbg)] ->
          let (addr, arg) = self#select_addressing chunk loc in
          (Ispecific(Ifloatsqrtf addr), [arg])
      | [arg] ->
@@ -237,11 +237,11 @@ method! select_operation op args dbg =
 
 method select_floatarith commutative regular_op mem_op args =
   match args with
-    [arg1; Cop(Cload ((Double|Double_u as chunk), _), [loc2], _)] ->
+    [arg1; Cop(Cload {memory_chunk=(Double|Double_u as chunk)}, [loc2], _)] ->
       let (addr, arg2) = self#select_addressing chunk loc2 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload ((Double|Double_u as chunk), _), [loc1], _); arg2]
+  | [Cop(Cload {memory_chunk=(Double|Double_u as chunk)}, [loc1], _); arg2]
         when commutative ->
       let (addr, arg1) = self#select_addressing chunk loc1 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -254,9 +254,9 @@ method private select_operation_softfp op args dbg =
       (Iintop_imm(Icomp(Iunsigned comp), 0),
        [Cop(Cextcall(func, typ_int, false, None), args, dbg)])
   (* Add coercions around loads and stores of 32-bit floats *)
-  | (Cload {memory_chunk=Single; mutability=mut; is_atomic=true}, args) ->
+  | (Cload {memory_chunk=Single; mutability=mut; is_atomic=false}, args) ->
       (self#iextcall("__aeabi_f2d", false),
-        [Cop(Cload {memory_chunk=Word_int; mutability=mut; is_atomic=true}, args, dbg)])
+        [Cop(Cload {memory_chunk=Word_int; mutability=mut; is_atomic=false}, args, dbg)])
   | (Cstore (Single, init), [arg1; arg2]) ->
       let arg2' =
         Cop(Cextcall("__aeabi_d2f", typ_int, false, None), [arg2], dbg) in

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -254,9 +254,9 @@ method private select_operation_softfp op args dbg =
       (Iintop_imm(Icomp(Iunsigned comp), 0),
        [Cop(Cextcall(func, typ_int, false, None), args, dbg)])
   (* Add coercions around loads and stores of 32-bit floats *)
-  | (Cload {memory_chunk=Single; mutability=mut; is_atomic=false}, args) ->
+  | (Cload {memory_chunk=Single; mutability; is_atomic=false}, args) ->
       (self#iextcall("__aeabi_f2d", false),
-        [Cop(Cload {memory_chunk=Word_int; mutability=mut; is_atomic=false}, args, dbg)])
+        [Cop(Cload {memory_chunk=Word_int; mutability; is_atomic=false}, args, dbg)])
   | (Cstore (Single, init), [arg1; arg2]) ->
       let arg2' =
         Cop(Cextcall("__aeabi_d2f", typ_int, false, None), [arg2], dbg) in

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -254,9 +254,9 @@ method private select_operation_softfp op args dbg =
       (Iintop_imm(Icomp(Iunsigned comp), 0),
        [Cop(Cextcall(func, typ_int, false, None), args, dbg)])
   (* Add coercions around loads and stores of 32-bit floats *)
-  | (Cload (Single, mut), args) ->
+  | (Cload {memory_chunk=Single; mutability=mut; is_atomic=true}, args) ->
       (self#iextcall("__aeabi_f2d", false),
-        [Cop(Cload (Word_int, mut), args, dbg)])
+        [Cop(Cload {memory_chunk=Word_int; mutability=mut; is_atomic=true}, args, dbg)])
   | (Cstore (Single, init), [arg1; arg2]) ->
       let arg2' =
         Cop(Cextcall("__aeabi_d2f", typ_int, false, None), [arg2], dbg) in

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -139,7 +139,7 @@ and operation =
       { memory_chunk: memory_chunk
       ; mutability: Asttypes.mutable_flag
       ; is_atomic: bool }
-  | Cloadmut
+  | Cloadmut of {is_atomic : bool}
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -135,7 +135,10 @@ and operation =
   | Cextcall of string * machtype * bool * label option
     (** If specified, the given label will be placed immediately after the
         call (at the same place as any frame descriptor would reference). *)
-  | Cload of memory_chunk * Asttypes.mutable_flag
+  | Cload of 
+      { memory_chunk: memory_chunk
+      ; mutability: Asttypes.mutable_flag
+      ; is_atomic: bool }
   | Cloadmut
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -110,7 +110,7 @@ and operation =
       { memory_chunk: memory_chunk
       ; mutability: Asttypes.mutable_flag
       ; is_atomic: bool }
-  | Cloadmut
+  | Cloadmut of {is_atomic : bool}
     (* Mutable loads = Cload {Word_val, Mutable}. It is a separate op since we
      * need the address of the object for read barrier. *)
   | Calloc

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -111,7 +111,7 @@ and operation =
       ; mutability: Asttypes.mutable_flag
       ; is_atomic: bool }
   | Cloadmut of {is_atomic : bool}
-    (* Mutable loads = Cload {Word_val, Mutable}. It is a separate op since we
+    (* Mutable loads = Cload {Word_val; Mutable; _}. It is a separate op since we
      * need the address of the object for read barrier. *)
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -106,9 +106,12 @@ type memory_chunk =
 and operation =
     Capply of machtype
   | Cextcall of string * machtype * bool * label option
-  | Cload of memory_chunk * Asttypes.mutable_flag
+  | Cload of
+      { memory_chunk: memory_chunk
+      ; mutability: Asttypes.mutable_flag
+      ; is_atomic: bool }
   | Cloadmut
-    (* Mutable loads = Cload (Word_val, Mutable. It is a separate op since we
+    (* Mutable loads = Cload {Word_val, Mutable}. It is a separate op since we
      * need the address of the object for read barrier. *)
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2091,7 +2091,7 @@ and transl_prim_1 env p arg dbg =
                    [untag_int (transl env arg) dbg],
                    dbg))
               dbg
-  | Patomic_load ->
+  | Patomic_load {immediate_or_pointer=_} ->
      Cop (Cextcall("caml_atomic_load", typ_val, true, None),
           [transl env arg], dbg)
   | prim ->

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2091,9 +2091,12 @@ and transl_prim_1 env p arg dbg =
                    [untag_int (transl env arg) dbg],
                    dbg))
               dbg
-  | Patomic_load {immediate_or_pointer=_} ->
-     Cop (Cextcall("caml_atomic_load", typ_val, true, None),
-          [transl env arg], dbg)
+  | Patomic_load {immediate_or_pointer} ->
+      let ptr = transl env arg
+      in
+      ( match immediate_or_pointer with
+        | Immediate -> Cop (Cload {memory_chunk=Word_int ; mutability=Mutable ; is_atomic=true} , [ptr; Cconst_int 0], dbg)
+        | Pointer -> Cop (Cloadmut {is_atomic=true}, [ptr; Cconst_int 0], dbg) )
   | prim ->
       fatal_errorf "Cmmgen.transl_prim_1: %a" Printlambda.primitive prim
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -541,15 +541,15 @@ let rec unbox_float dbg cmm =
   | Ccatch(rec_flag, handlers, body) ->
     map_ccatch (unbox_float dbg) rec_flag handlers body
   | Ctrywith(e1, id, e2) -> Ctrywith(unbox_float dbg e1, id, unbox_float dbg e2)
-  | c -> Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=true}, [c], dbg)
+  | c -> Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=false}, [c], dbg)
 
 (* Complex *)
 
 let box_complex dbg c_re c_im =
   Cop(Calloc, [alloc_floatarray_header 2 dbg; c_re; c_im], dbg)
 
-let complex_re c dbg = Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=true}, [c], dbg)
-let complex_im c dbg = Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=true},
+let complex_re c dbg = Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=false}, [c], dbg)
+let complex_im c dbg = Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=false},
                         [Cop(Cadda, [c; Cconst_int size_float], dbg)], dbg)
 
 (* Unit *)
@@ -587,7 +587,7 @@ let field_address ptr n dbg =
   else Cop(Cadda, [ptr; Cconst_int(n * size_addr)], dbg)
 
 let get_mut_field ptr n dbg =
-  Cop (Cloadmut, [ptr; n], dbg)
+  Cop (Cloadmut {is_atomic=false}, [ptr; n], dbg)
 
 let get_field env ptr n dbg =
   let mut =
@@ -601,7 +601,7 @@ let get_field env ptr n dbg =
         else Mutable
       | _ -> Mutable
   in
-  Cop(Cload {memory_chunk=Word_val; mutability=mut; is_atomic=true}, [field_address ptr n dbg], dbg)
+  Cop(Cload {memory_chunk=Word_val; mutability=mut; is_atomic=false}, [field_address ptr n dbg], dbg)
 
 let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
@@ -611,7 +611,7 @@ let non_profinfo_mask = (1 lsl (64 - Config.profinfo_width)) - 1
 let get_header ptr dbg =
   (* We cannot deem this as [Immutable] due to the presence of [Obj.truncate]
      and [Obj.set_tag]. *)
-  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
     [Cop(Cadda, [ptr; Cconst_int(-size_int)], dbg)], dbg)
 
 let get_header_without_profinfo ptr dbg =
@@ -627,7 +627,7 @@ let get_tag ptr dbg =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [get_header ptr dbg; Cconst_int 255], dbg)
   else                                  (* If byte loads are efficient *)
-    Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, (* Same comment as [get_header] above *)
+    Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, (* Same comment as [get_header] above *)
         [Cop(Cadda, [ptr; Cconst_int(tag_offset)], dbg)], dbg)
 
 let get_size ptr dbg =
@@ -689,12 +689,12 @@ let array_indexing ?typ log2size ptr ofs dbg =
                     Cconst_int((-1) lsl (log2size - 1))], dbg)
 
 let addr_array_ref arr ofs dbg =
-  Cop(Cloadmut, [arr; untag_int ofs dbg], dbg)
+  Cop(Cloadmut {is_atomic=false}, [arr; untag_int ofs dbg], dbg)
 let int_array_ref arr ofs dbg =
-  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
     [array_indexing log2_size_addr arr ofs dbg], dbg)
 let unboxed_float_array_ref arr ofs dbg =
-  Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=true},
+  Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=false},
     [array_indexing log2_size_float arr ofs dbg], dbg)
 let float_array_ref dbg arr ofs =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
@@ -729,7 +729,7 @@ let string_length exp dbg =
              dbg),
          Cop(Csubi,
              [Cvar tmp_var;
-               Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+               Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                      [Cop(Cadda, [str; Cvar tmp_var], dbg)], dbg)], dbg)))
 
 (* Message sending *)
@@ -742,7 +742,7 @@ let lookup_tag obj tag dbg =
 
 let lookup_label obj lab dbg =
   bind "lab" lab (fun lab ->
-    let table = Cop (Cloadmut, [obj; Cconst_int 0], dbg) in
+    let table = Cop (Cloadmut {is_atomic=false}, [obj; Cconst_int 0], dbg) in
                      (* Should this be Cloadmut? *)
     addr_array_ref table lab dbg)
 
@@ -948,8 +948,8 @@ let split_int64_for_32bit_target arg dbg =
   bind "split_int64" arg (fun arg ->
     let first = Cop (Cadda, [Cconst_int size_int; arg], dbg) in
     let second = Cop (Cadda, [Cconst_int (2 * size_int); arg], dbg) in
-    Ctuple [Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=true}, [first], dbg);
-            Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=true}, [second], dbg)])
+    Ctuple [Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=false}, [first], dbg);
+            Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=false}, [second], dbg)])
 
 let rec unbox_int bi arg dbg =
   match arg with
@@ -981,7 +981,7 @@ let rec unbox_int bi arg dbg =
         let memory_chunk = if bi = Pint32 then Thirtytwo_signed else Word_int
         in
         Cop(
-          Cload {memory_chunk; mutability=Mutable; is_atomic=true},
+          Cload {memory_chunk; mutability=Mutable; is_atomic=false},
           [Cop(Cadda, [arg; Cconst_int size_addr], dbg)], dbg)
 
 let make_unsigned_int bi arg dbg =
@@ -1044,7 +1044,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
         bind "idx" arg (fun idx ->
           (* Load the untagged int bound for the given dimension *)
           let bound =
-            Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},[field_address b dim_ofs dbg], dbg)
+            Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},[field_address b dim_ofs dbg], dbg)
           in
           let idxn = untag_int idx dbg in
           check_ba_bound bound idxn idx)
@@ -1054,7 +1054,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
       let rem = ba_indexing (dim_ofs + delta_ofs) delta_ofs argl in
       (* Load the untagged int bound for the given dimension *)
       let bound =
-        Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address b dim_ofs dbg], dbg)
+        Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address b dim_ofs dbg], dbg)
       in
       if unsafe then add_int (mul_int (decr_int rem dbg) bound dbg) arg1 dbg
       else
@@ -1080,7 +1080,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
     bigarray_elt_size elt_kind in
   (* [array_indexing] can simplify the given expressions *)
   array_indexing ~typ:Int (log2 elt_size)
-                 (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+                 (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                     [field_address b 1 dbg], dbg)) offset dbg
 
 let bigarray_word_kind = function
@@ -1107,11 +1107,11 @@ let bigarray_get unsafe elt_kind layout b args dbg =
         bind "addr" (bigarray_indexing unsafe elt_kind layout b args dbg)
           (fun addr ->
           box_complex dbg
-            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=true}, [addr], dbg))
-            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=true},
+            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=false}, [addr], dbg))
+            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=false},
               [Cop(Cadda, [addr; Cconst_int sz], dbg)], dbg)))
     | _ ->
-            Cop(Cload {memory_chunk=bigarray_word_kind elt_kind; mutability=Mutable; is_atomic=true},
+            Cop(Cload {memory_chunk=bigarray_word_kind elt_kind; mutability=Mutable; is_atomic=false},
             [bigarray_indexing unsafe elt_kind layout b args dbg],
             dbg))
 
@@ -1136,10 +1136,10 @@ let bigarray_set unsafe elt_kind layout b args newval dbg =
 
 let unaligned_load_16 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload {memory_chunk=Sixteen_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg)
+  then Cop(Cload {memory_chunk=Sixteen_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Cop(Cor, [lsl_int b1 (Cconst_int 8) dbg; b2], dbg)
@@ -1162,14 +1162,14 @@ let unaligned_set_16 ptr idx newval dbg =
 
 let unaligned_load_32 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg)
+  then Cop(Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
     let b1, b2, b3, b4 =
       if Arch.big_endian
@@ -1216,22 +1216,22 @@ let unaligned_set_32 ptr idx newval dbg =
 let unaligned_load_64 ptr idx dbg =
   assert(size_int = 8);
   if Arch.allow_unaligned_access
-  then Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg)
+  then Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
-    let v5 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v5 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 4) dbg], dbg) in
-    let v6 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v6 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 5) dbg], dbg) in
-    let v7 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v7 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 6) dbg], dbg) in
-    let v8 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+    let v8 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                  [add_int (add_int ptr idx dbg) (Cconst_int 7) dbg], dbg) in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
       if Arch.big_endian
@@ -1819,7 +1819,7 @@ let rec transl env e =
             dbg)
       | (Pbigarraydim(n), [b]) ->
           let dim_ofs = 4 + n in
-          tag_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+          tag_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
             [field_address (transl env b) dim_ofs dbg],
             dbg)) dbg
       | (p, [arg]) ->
@@ -1923,7 +1923,7 @@ let rec transl env e =
       end
   | Uunreachable ->
       let dbg = Debuginfo.none in
-      Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [Cconst_int 0], dbg)
+      Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [Cconst_int 0], dbg)
 
 and transl_make_array dbg env kind args =
   match kind with
@@ -1983,7 +1983,7 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield n ->
       let ptr = transl env arg in
       box_float dbg (
-        Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=true},
+        Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=false},
             [if n = 0 then ptr
                        else Cop(Cadda, [ptr; Cconst_int(n * size_float)], dbg)],
             dbg))
@@ -2026,7 +2026,7 @@ and transl_prim_1 env p arg dbg =
         (bind "ref" (transl env arg) (fun arg ->
           Cop(Cstore (Word_int, Assignment),
               [arg;
-               add_const (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [arg], dbg))
+               add_const (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [arg], dbg))
                  (n lsl 1) dbg],
               dbg)))
   (* Floating-point operations *)
@@ -2207,7 +2207,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
 
   (* String operations *)
   | Pstringrefu | Pbytesrefu ->
-      tag_int(Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+      tag_int(Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                   [add_int (transl env arg1) (untag_int(transl env arg2) dbg)
                     dbg],
                   dbg)) dbg
@@ -2217,7 +2217,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
           bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
             Csequence(
               make_checkbound dbg [string_length str dbg; idx],
-              Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+              Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                 [add_int str idx dbg], dbg))))) dbg
 
   | Pstring_load_16(unsafe) ->
@@ -2233,9 +2233,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
+         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1) dbg) idx
                       (unaligned_load_16 ba_data idx dbg))))) dbg
@@ -2253,9 +2253,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
+         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3) dbg) idx
                       (unaligned_load_32 ba_data idx dbg)))))
@@ -2273,9 +2273,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
+         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7) dbg) idx
                       (unaligned_load_64 ba_data idx dbg)))))
@@ -2340,7 +2340,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Pbittest ->
       bind "index" (untag_int(transl env arg2) dbg) (fun idx ->
         tag_int(
-          Cop(Cand, [Cop(Clsr, [Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
+          Cop(Cand, [Cop(Clsr, [Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
                                     [add_int (transl env arg1)
                                       (Cop(Clsr, [idx; Cconst_int 3], dbg))
                                       dbg],
@@ -2524,9 +2524,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (untag_int (transl env arg3) dbg) (fun newval ->
         bind "ba_data"
-             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
+             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1)
                                           dbg)
@@ -2547,9 +2547,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint32 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
+             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3)
                                           dbg)
@@ -2570,9 +2570,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint64 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
+             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7)
                                           dbg) idx
@@ -3099,7 +3099,7 @@ let cache_public_method meths tag cache dbg =
   Clet (
   li, Cconst_int 3,
   Clet (
-  hi, Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [meths], dbg),
+  hi, Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [meths], dbg),
   Csequence(
   ccatch
     (raise_num, [],
@@ -3115,7 +3115,7 @@ let cache_public_method meths tag cache dbg =
         Cifthenelse
           (Cop (Ccmpi Clt,
                 [tag;
-                 Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+                 Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                      [Cop(Cadda,
                           [meths; lsl_const (Cvar mi) log2_size_addr dbg],
                           dbg)],
@@ -3186,12 +3186,12 @@ let send_function arity =
     let cached_pos = Cvar cached in
     let tag_pos = Cop(Cadda, [Cop (Cadda, [cached_pos; Cvar meths], dbg);
                               Cconst_int(3*size_addr-1)], dbg) in
-    let tag' = Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [tag_pos], dbg) in
+    let tag' = Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [tag_pos], dbg) in
     Clet (
     meths, get_mut_field obj (Cconst_int 0) dbg,
     Clet (
     cached,
-      Cop(Cand, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [cache], dbg); mask], dbg),
+      Cop(Cand, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [cache], dbg); mask], dbg),
     Clet (
     real,
     Cifthenelse(Cop(Ccmpa Cne, [tag'; tag], dbg),
@@ -3418,7 +3418,7 @@ let entry_point namelist =
   let incr_global_inited =
     Cop(Cstore (Word_int, Assignment),
         [Cconst_symbol "caml_globals_inited";
-         Cop(Caddi, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
+         Cop(Caddi, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
                        [Cconst_symbol "caml_globals_inited"], dbg);
                      Cconst_int 1], dbg)], dbg) in
   let body =

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -80,6 +80,8 @@ let bind_nonvar name arg fn =
 let caml_black = Nativeint.shift_left (Nativeint.of_int 3) 8
     (* cf. byterun/gc.h *)
 
+let mk_load_mut memory_chunk = Cload {memory_chunk; mutability=Mutable; is_atomic=false}
+
 (* Block headers. Meaning of the tag field: see stdlib/obj.ml *)
 
 let floatarray_tag = Cconst_int Obj.double_array_tag
@@ -590,7 +592,7 @@ let get_mut_field ptr n dbg =
   Cop (Cloadmut {is_atomic=false}, [ptr; n], dbg)
 
 let get_field env ptr n dbg =
-  let mut =
+  let mutability =
     match env.environment_param with
     | None -> Mutable
     | Some environment_param ->
@@ -601,7 +603,7 @@ let get_field env ptr n dbg =
         else Mutable
       | _ -> Mutable
   in
-  Cop(Cload {memory_chunk=Word_val; mutability=mut; is_atomic=false}, [field_address ptr n dbg], dbg)
+  Cop(Cload {memory_chunk=Word_val; mutability; is_atomic=false}, [field_address ptr n dbg], dbg)
 
 let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
@@ -611,7 +613,7 @@ let non_profinfo_mask = (1 lsl (64 - Config.profinfo_width)) - 1
 let get_header ptr dbg =
   (* We cannot deem this as [Immutable] due to the presence of [Obj.truncate]
      and [Obj.set_tag]. *)
-  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+  Cop(mk_load_mut Word_int,
     [Cop(Cadda, [ptr; Cconst_int(-size_int)], dbg)], dbg)
 
 let get_header_without_profinfo ptr dbg =
@@ -627,7 +629,7 @@ let get_tag ptr dbg =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [get_header ptr dbg; Cconst_int 255], dbg)
   else                                  (* If byte loads are efficient *)
-    Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, (* Same comment as [get_header] above *)
+    Cop(mk_load_mut Byte_unsigned, (* Same comment as [get_header] above *)
         [Cop(Cadda, [ptr; Cconst_int(tag_offset)], dbg)], dbg)
 
 let get_size ptr dbg =
@@ -691,10 +693,10 @@ let array_indexing ?typ log2size ptr ofs dbg =
 let addr_array_ref arr ofs dbg =
   Cop(Cloadmut {is_atomic=false}, [arr; untag_int ofs dbg], dbg)
 let int_array_ref arr ofs dbg =
-  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+  Cop(mk_load_mut Word_int,
     [array_indexing log2_size_addr arr ofs dbg], dbg)
 let unboxed_float_array_ref arr ofs dbg =
-  Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=false},
+  Cop(mk_load_mut Double_u,
     [array_indexing log2_size_float arr ofs dbg], dbg)
 let float_array_ref dbg arr ofs =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
@@ -729,7 +731,7 @@ let string_length exp dbg =
              dbg),
          Cop(Csubi,
              [Cvar tmp_var;
-               Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+               Cop(mk_load_mut Byte_unsigned,
                      [Cop(Cadda, [str; Cvar tmp_var], dbg)], dbg)], dbg)))
 
 (* Message sending *)
@@ -948,8 +950,8 @@ let split_int64_for_32bit_target arg dbg =
   bind "split_int64" arg (fun arg ->
     let first = Cop (Cadda, [Cconst_int size_int; arg], dbg) in
     let second = Cop (Cadda, [Cconst_int (2 * size_int); arg], dbg) in
-    Ctuple [Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=false}, [first], dbg);
-            Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=false}, [second], dbg)])
+    Ctuple [Cop (mk_load_mut Thirtytwo_unsigned, [first], dbg);
+            Cop (mk_load_mut Thirtytwo_unsigned, [second], dbg)])
 
 let rec unbox_int bi arg dbg =
   match arg with
@@ -1044,7 +1046,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
         bind "idx" arg (fun idx ->
           (* Load the untagged int bound for the given dimension *)
           let bound =
-            Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},[field_address b dim_ofs dbg], dbg)
+            Cop(mk_load_mut Word_int,[field_address b dim_ofs dbg], dbg)
           in
           let idxn = untag_int idx dbg in
           check_ba_bound bound idxn idx)
@@ -1054,7 +1056,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
       let rem = ba_indexing (dim_ofs + delta_ofs) delta_ofs argl in
       (* Load the untagged int bound for the given dimension *)
       let bound =
-        Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address b dim_ofs dbg], dbg)
+        Cop(mk_load_mut Word_int, [field_address b dim_ofs dbg], dbg)
       in
       if unsafe then add_int (mul_int (decr_int rem dbg) bound dbg) arg1 dbg
       else
@@ -1080,7 +1082,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
     bigarray_elt_size elt_kind in
   (* [array_indexing] can simplify the given expressions *)
   array_indexing ~typ:Int (log2 elt_size)
-                 (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+                 (Cop(mk_load_mut Word_int,
                     [field_address b 1 dbg], dbg)) offset dbg
 
 let bigarray_word_kind = function
@@ -1107,11 +1109,11 @@ let bigarray_get unsafe elt_kind layout b args dbg =
         bind "addr" (bigarray_indexing unsafe elt_kind layout b args dbg)
           (fun addr ->
           box_complex dbg
-            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=false}, [addr], dbg))
-            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=false},
+            (Cop(mk_load_mut kind, [addr], dbg))
+            (Cop(mk_load_mut kind,
               [Cop(Cadda, [addr; Cconst_int sz], dbg)], dbg)))
     | _ ->
-            Cop(Cload {memory_chunk=bigarray_word_kind elt_kind; mutability=Mutable; is_atomic=false},
+            Cop(mk_load_mut (bigarray_word_kind elt_kind),
             [bigarray_indexing unsafe elt_kind layout b args dbg],
             dbg))
 
@@ -1136,10 +1138,10 @@ let bigarray_set unsafe elt_kind layout b args newval dbg =
 
 let unaligned_load_16 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload {memory_chunk=Sixteen_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg)
+  then Cop(mk_load_mut Sixteen_unsigned, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Cop(Cor, [lsl_int b1 (Cconst_int 8) dbg; b2], dbg)
@@ -1162,14 +1164,14 @@ let unaligned_set_16 ptr idx newval dbg =
 
 let unaligned_load_32 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg)
+  then Cop(mk_load_mut Thirtytwo_unsigned, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v3 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v4 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
     let b1, b2, b3, b4 =
       if Arch.big_endian
@@ -1216,22 +1218,22 @@ let unaligned_set_32 ptr idx newval dbg =
 let unaligned_load_64 ptr idx dbg =
   assert(size_int = 8);
   if Arch.allow_unaligned_access
-  then Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg)
+  then Cop(mk_load_mut Word_int, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false}, [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v1 = Cop(mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v3 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v4 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
-    let v5 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v5 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 4) dbg], dbg) in
-    let v6 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v6 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 5) dbg], dbg) in
-    let v7 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v7 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 6) dbg], dbg) in
-    let v8 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+    let v8 = Cop(mk_load_mut Byte_unsigned,
                  [add_int (add_int ptr idx dbg) (Cconst_int 7) dbg], dbg) in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
       if Arch.big_endian
@@ -1819,7 +1821,7 @@ let rec transl env e =
             dbg)
       | (Pbigarraydim(n), [b]) ->
           let dim_ofs = 4 + n in
-          tag_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+          tag_int (Cop(mk_load_mut Word_int,
             [field_address (transl env b) dim_ofs dbg],
             dbg)) dbg
       | (p, [arg]) ->
@@ -1923,7 +1925,7 @@ let rec transl env e =
       end
   | Uunreachable ->
       let dbg = Debuginfo.none in
-      Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [Cconst_int 0], dbg)
+      Cop(mk_load_mut Word_int, [Cconst_int 0], dbg)
 
 and transl_make_array dbg env kind args =
   match kind with
@@ -1983,7 +1985,7 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield n ->
       let ptr = transl env arg in
       box_float dbg (
-        Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=false},
+        Cop(mk_load_mut Double_u,
             [if n = 0 then ptr
                        else Cop(Cadda, [ptr; Cconst_int(n * size_float)], dbg)],
             dbg))
@@ -2026,7 +2028,7 @@ and transl_prim_1 env p arg dbg =
         (bind "ref" (transl env arg) (fun arg ->
           Cop(Cstore (Word_int, Assignment),
               [arg;
-               add_const (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [arg], dbg))
+               add_const (Cop(mk_load_mut Word_int, [arg], dbg))
                  (n lsl 1) dbg],
               dbg)))
   (* Floating-point operations *)
@@ -2210,7 +2212,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
 
   (* String operations *)
   | Pstringrefu | Pbytesrefu ->
-      tag_int(Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+      tag_int(Cop(mk_load_mut Byte_unsigned,
                   [add_int (transl env arg1) (untag_int(transl env arg2) dbg)
                     dbg],
                   dbg)) dbg
@@ -2220,7 +2222,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
           bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
             Csequence(
               make_checkbound dbg [string_length str dbg; idx],
-              Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+              Cop(mk_load_mut Byte_unsigned,
                 [add_int str idx dbg], dbg))))) dbg
 
   | Pstring_load_16(unsafe) ->
@@ -2236,9 +2238,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
+         (Cop(mk_load_mut Word_int, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+          check_bound unsafe dbg (sub_int (Cop(mk_load_mut Word_int,
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1) dbg) idx
                       (unaligned_load_16 ba_data idx dbg))))) dbg
@@ -2256,9 +2258,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
+         (Cop(mk_load_mut Word_int, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+          check_bound unsafe dbg (sub_int (Cop(mk_load_mut Word_int,
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3) dbg) idx
                       (unaligned_load_32 ba_data idx dbg)))))
@@ -2276,9 +2278,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
+         (Cop(mk_load_mut Word_int, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+          check_bound unsafe dbg (sub_int (Cop(mk_load_mut Word_int,
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7) dbg) idx
                       (unaligned_load_64 ba_data idx dbg)))))
@@ -2343,7 +2345,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Pbittest ->
       bind "index" (untag_int(transl env arg2) dbg) (fun idx ->
         tag_int(
-          Cop(Cand, [Cop(Clsr, [Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=false},
+          Cop(Cand, [Cop(Clsr, [Cop(mk_load_mut Byte_unsigned,
                                     [add_int (transl env arg1)
                                       (Cop(Clsr, [idx; Cconst_int 3], dbg))
                                       dbg],
@@ -2527,9 +2529,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (untag_int (transl env arg3) dbg) (fun newval ->
         bind "ba_data"
-             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
+             (Cop(mk_load_mut Word_int, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+          check_bound unsafe dbg (sub_int (Cop(mk_load_mut Word_int,
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1)
                                           dbg)
@@ -2550,9 +2552,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint32 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
+             (Cop(mk_load_mut Word_int, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+          check_bound unsafe dbg (sub_int (Cop(mk_load_mut Word_int,
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3)
                                           dbg)
@@ -2573,9 +2575,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint64 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [field_address ba 1 dbg], dbg))
+             (Cop(mk_load_mut Word_int, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+          check_bound unsafe dbg (sub_int (Cop(mk_load_mut Word_int,
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7)
                                           dbg) idx
@@ -3102,7 +3104,7 @@ let cache_public_method meths tag cache dbg =
   Clet (
   li, Cconst_int 3,
   Clet (
-  hi, Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [meths], dbg),
+  hi, Cop(mk_load_mut Word_int, [meths], dbg),
   Csequence(
   ccatch
     (raise_num, [],
@@ -3118,7 +3120,7 @@ let cache_public_method meths tag cache dbg =
         Cifthenelse
           (Cop (Ccmpi Clt,
                 [tag;
-                 Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+                 Cop(mk_load_mut Word_int,
                      [Cop(Cadda,
                           [meths; lsl_const (Cvar mi) log2_size_addr dbg],
                           dbg)],
@@ -3189,12 +3191,12 @@ let send_function arity =
     let cached_pos = Cvar cached in
     let tag_pos = Cop(Cadda, [Cop (Cadda, [cached_pos; Cvar meths], dbg);
                               Cconst_int(3*size_addr-1)], dbg) in
-    let tag' = Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [tag_pos], dbg) in
+    let tag' = Cop(mk_load_mut Word_int, [tag_pos], dbg) in
     Clet (
     meths, get_mut_field obj (Cconst_int 0) dbg,
     Clet (
     cached,
-      Cop(Cand, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [cache], dbg); mask], dbg),
+      Cop(Cand, [Cop(mk_load_mut Word_int, [cache], dbg); mask], dbg),
     Clet (
     real,
     Cifthenelse(Cop(Ccmpa Cne, [tag'; tag], dbg),
@@ -3421,7 +3423,7 @@ let entry_point namelist =
   let incr_global_inited =
     Cop(Cstore (Word_int, Assignment),
         [Cconst_symbol "caml_globals_inited";
-         Cop(Caddi, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false},
+         Cop(Caddi, [Cop(mk_load_mut Word_int,
                        [Cconst_symbol "caml_globals_inited"], dbg);
                      Cconst_int 1], dbg)], dbg) in
   let body =

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -541,15 +541,15 @@ let rec unbox_float dbg cmm =
   | Ccatch(rec_flag, handlers, body) ->
     map_ccatch (unbox_float dbg) rec_flag handlers body
   | Ctrywith(e1, id, e2) -> Ctrywith(unbox_float dbg e1, id, unbox_float dbg e2)
-  | c -> Cop(Cload (Double_u, Immutable), [c], dbg)
+  | c -> Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=true}, [c], dbg)
 
 (* Complex *)
 
 let box_complex dbg c_re c_im =
   Cop(Calloc, [alloc_floatarray_header 2 dbg; c_re; c_im], dbg)
 
-let complex_re c dbg = Cop(Cload (Double_u, Immutable), [c], dbg)
-let complex_im c dbg = Cop(Cload (Double_u, Immutable),
+let complex_re c dbg = Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=true}, [c], dbg)
+let complex_im c dbg = Cop(Cload {memory_chunk=Double_u; mutability=Immutable; is_atomic=true},
                         [Cop(Cadda, [c; Cconst_int size_float], dbg)], dbg)
 
 (* Unit *)
@@ -601,7 +601,7 @@ let get_field env ptr n dbg =
         else Mutable
       | _ -> Mutable
   in
-  Cop(Cload (Word_val, mut), [field_address ptr n dbg], dbg)
+  Cop(Cload {memory_chunk=Word_val; mutability=mut; is_atomic=true}, [field_address ptr n dbg], dbg)
 
 let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
@@ -611,7 +611,7 @@ let non_profinfo_mask = (1 lsl (64 - Config.profinfo_width)) - 1
 let get_header ptr dbg =
   (* We cannot deem this as [Immutable] due to the presence of [Obj.truncate]
      and [Obj.set_tag]. *)
-  Cop(Cload (Word_int, Mutable),
+  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
     [Cop(Cadda, [ptr; Cconst_int(-size_int)], dbg)], dbg)
 
 let get_header_without_profinfo ptr dbg =
@@ -627,7 +627,7 @@ let get_tag ptr dbg =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [get_header ptr dbg; Cconst_int 255], dbg)
   else                                  (* If byte loads are efficient *)
-    Cop(Cload (Byte_unsigned, Mutable), (* Same comment as [get_header] above *)
+    Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, (* Same comment as [get_header] above *)
         [Cop(Cadda, [ptr; Cconst_int(tag_offset)], dbg)], dbg)
 
 let get_size ptr dbg =
@@ -691,10 +691,10 @@ let array_indexing ?typ log2size ptr ofs dbg =
 let addr_array_ref arr ofs dbg =
   Cop(Cloadmut, [arr; untag_int ofs dbg], dbg)
 let int_array_ref arr ofs dbg =
-  Cop(Cload (Word_int, Mutable),
+  Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
     [array_indexing log2_size_addr arr ofs dbg], dbg)
 let unboxed_float_array_ref arr ofs dbg =
-  Cop(Cload (Double_u, Mutable),
+  Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=true},
     [array_indexing log2_size_float arr ofs dbg], dbg)
 let float_array_ref dbg arr ofs =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
@@ -729,7 +729,7 @@ let string_length exp dbg =
              dbg),
          Cop(Csubi,
              [Cvar tmp_var;
-               Cop(Cload (Byte_unsigned, Mutable),
+               Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                      [Cop(Cadda, [str; Cvar tmp_var], dbg)], dbg)], dbg)))
 
 (* Message sending *)
@@ -948,8 +948,8 @@ let split_int64_for_32bit_target arg dbg =
   bind "split_int64" arg (fun arg ->
     let first = Cop (Cadda, [Cconst_int size_int; arg], dbg) in
     let second = Cop (Cadda, [Cconst_int (2 * size_int); arg], dbg) in
-    Ctuple [Cop (Cload (Thirtytwo_unsigned, Mutable), [first], dbg);
-            Cop (Cload (Thirtytwo_unsigned, Mutable), [second], dbg)])
+    Ctuple [Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=true}, [first], dbg);
+            Cop (Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=true}, [second], dbg)])
 
 let rec unbox_int bi arg dbg =
   match arg with
@@ -978,8 +978,10 @@ let rec unbox_int bi arg dbg =
       if size_int = 4 && bi = Pint64 then
         split_int64_for_32bit_target arg dbg
       else
+        let memory_chunk = if bi = Pint32 then Thirtytwo_signed else Word_int
+        in
         Cop(
-          Cload((if bi = Pint32 then Thirtytwo_signed else Word_int), Mutable),
+          Cload {memory_chunk; mutability=Mutable; is_atomic=true},
           [Cop(Cadda, [arg; Cconst_int size_addr], dbg)], dbg)
 
 let make_unsigned_int bi arg dbg =
@@ -1042,7 +1044,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
         bind "idx" arg (fun idx ->
           (* Load the untagged int bound for the given dimension *)
           let bound =
-            Cop(Cload (Word_int, Mutable),[field_address b dim_ofs dbg], dbg)
+            Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},[field_address b dim_ofs dbg], dbg)
           in
           let idxn = untag_int idx dbg in
           check_ba_bound bound idxn idx)
@@ -1052,7 +1054,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
       let rem = ba_indexing (dim_ofs + delta_ofs) delta_ofs argl in
       (* Load the untagged int bound for the given dimension *)
       let bound =
-        Cop(Cload (Word_int, Mutable), [field_address b dim_ofs dbg], dbg)
+        Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address b dim_ofs dbg], dbg)
       in
       if unsafe then add_int (mul_int (decr_int rem dbg) bound dbg) arg1 dbg
       else
@@ -1078,7 +1080,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
     bigarray_elt_size elt_kind in
   (* [array_indexing] can simplify the given expressions *)
   array_indexing ~typ:Int (log2 elt_size)
-                 (Cop(Cload (Word_int, Mutable),
+                 (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                     [field_address b 1 dbg], dbg)) offset dbg
 
 let bigarray_word_kind = function
@@ -1105,11 +1107,11 @@ let bigarray_get unsafe elt_kind layout b args dbg =
         bind "addr" (bigarray_indexing unsafe elt_kind layout b args dbg)
           (fun addr ->
           box_complex dbg
-            (Cop(Cload (kind, Mutable), [addr], dbg))
-            (Cop(Cload (kind, Mutable),
+            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=true}, [addr], dbg))
+            (Cop(Cload {memory_chunk=kind; mutability=Mutable; is_atomic=true},
               [Cop(Cadda, [addr; Cconst_int sz], dbg)], dbg)))
     | _ ->
-        Cop(Cload (bigarray_word_kind elt_kind, Mutable),
+            Cop(Cload {memory_chunk=bigarray_word_kind elt_kind; mutability=Mutable; is_atomic=true},
             [bigarray_indexing unsafe elt_kind layout b args dbg],
             dbg))
 
@@ -1134,10 +1136,10 @@ let bigarray_set unsafe elt_kind layout b args newval dbg =
 
 let unaligned_load_16 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload (Sixteen_unsigned, Mutable), [add_int ptr idx dbg], dbg)
+  then Cop(Cload {memory_chunk=Sixteen_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload (Byte_unsigned, Mutable),
+    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Cop(Cor, [lsl_int b1 (Cconst_int 8) dbg; b2], dbg)
@@ -1160,14 +1162,14 @@ let unaligned_set_16 ptr idx newval dbg =
 
 let unaligned_load_32 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload (Thirtytwo_unsigned, Mutable), [add_int ptr idx dbg], dbg)
+  then Cop(Cload {memory_chunk=Thirtytwo_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload (Byte_unsigned, Mutable),
+    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload (Byte_unsigned, Mutable),
+    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload (Byte_unsigned, Mutable),
+    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
     let b1, b2, b3, b4 =
       if Arch.big_endian
@@ -1214,22 +1216,22 @@ let unaligned_set_32 ptr idx newval dbg =
 let unaligned_load_64 ptr idx dbg =
   assert(size_int = 8);
   if Arch.allow_unaligned_access
-  then Cop(Cload (Word_int, Mutable), [add_int ptr idx dbg], dbg)
+  then Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload (Byte_unsigned, Mutable),
+    let v1 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true}, [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload (Byte_unsigned, Mutable),
+    let v3 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload (Byte_unsigned, Mutable),
+    let v4 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
-    let v5 = Cop(Cload (Byte_unsigned, Mutable),
+    let v5 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 4) dbg], dbg) in
-    let v6 = Cop(Cload (Byte_unsigned, Mutable),
+    let v6 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 5) dbg], dbg) in
-    let v7 = Cop(Cload (Byte_unsigned, Mutable),
+    let v7 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 6) dbg], dbg) in
-    let v8 = Cop(Cload (Byte_unsigned, Mutable),
+    let v8 = Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                  [add_int (add_int ptr idx dbg) (Cconst_int 7) dbg], dbg) in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
       if Arch.big_endian
@@ -1817,7 +1819,7 @@ let rec transl env e =
             dbg)
       | (Pbigarraydim(n), [b]) ->
           let dim_ofs = 4 + n in
-          tag_int (Cop(Cload (Word_int, Mutable),
+          tag_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
             [field_address (transl env b) dim_ofs dbg],
             dbg)) dbg
       | (p, [arg]) ->
@@ -1921,7 +1923,7 @@ let rec transl env e =
       end
   | Uunreachable ->
       let dbg = Debuginfo.none in
-      Cop(Cload (Word_int, Mutable), [Cconst_int 0], dbg)
+      Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [Cconst_int 0], dbg)
 
 and transl_make_array dbg env kind args =
   match kind with
@@ -1981,7 +1983,7 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield n ->
       let ptr = transl env arg in
       box_float dbg (
-        Cop(Cload (Double_u, Mutable),
+        Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=true},
             [if n = 0 then ptr
                        else Cop(Cadda, [ptr; Cconst_int(n * size_float)], dbg)],
             dbg))
@@ -2024,7 +2026,7 @@ and transl_prim_1 env p arg dbg =
         (bind "ref" (transl env arg) (fun arg ->
           Cop(Cstore (Word_int, Assignment),
               [arg;
-               add_const (Cop(Cload (Word_int, Mutable), [arg], dbg))
+               add_const (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [arg], dbg))
                  (n lsl 1) dbg],
               dbg)))
   (* Floating-point operations *)
@@ -2205,7 +2207,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
 
   (* String operations *)
   | Pstringrefu | Pbytesrefu ->
-      tag_int(Cop(Cload (Byte_unsigned, Mutable),
+      tag_int(Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                   [add_int (transl env arg1) (untag_int(transl env arg2) dbg)
                     dbg],
                   dbg)) dbg
@@ -2215,7 +2217,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
           bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
             Csequence(
               make_checkbound dbg [string_length str dbg; idx],
-              Cop(Cload (Byte_unsigned, Mutable),
+              Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                 [add_int str idx dbg], dbg))))) dbg
 
   | Pstring_load_16(unsafe) ->
@@ -2231,9 +2233,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1) dbg) idx
                       (unaligned_load_16 ba_data idx dbg))))) dbg
@@ -2251,9 +2253,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3) dbg) idx
                       (unaligned_load_32 ba_data idx dbg)))))
@@ -2271,9 +2273,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+         (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7) dbg) idx
                       (unaligned_load_64 ba_data idx dbg)))))
@@ -2338,7 +2340,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Pbittest ->
       bind "index" (untag_int(transl env arg2) dbg) (fun idx ->
         tag_int(
-          Cop(Cand, [Cop(Clsr, [Cop(Cload (Byte_unsigned, Mutable),
+          Cop(Cand, [Cop(Clsr, [Cop(Cload {memory_chunk=Byte_unsigned; mutability=Mutable; is_atomic=true},
                                     [add_int (transl env arg1)
                                       (Cop(Clsr, [idx; Cconst_int 3], dbg))
                                       dbg],
@@ -2522,9 +2524,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (untag_int (transl env arg3) dbg) (fun newval ->
         bind "ba_data"
-             (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1)
                                           dbg)
@@ -2545,9 +2547,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint32 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3)
                                           dbg)
@@ -2568,9 +2570,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint64 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+             (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7)
                                           dbg) idx
@@ -3097,7 +3099,7 @@ let cache_public_method meths tag cache dbg =
   Clet (
   li, Cconst_int 3,
   Clet (
-  hi, Cop(Cload (Word_int, Mutable), [meths], dbg),
+  hi, Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [meths], dbg),
   Csequence(
   ccatch
     (raise_num, [],
@@ -3113,7 +3115,7 @@ let cache_public_method meths tag cache dbg =
         Cifthenelse
           (Cop (Ccmpi Clt,
                 [tag;
-                 Cop(Cload (Word_int, Mutable),
+                 Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                      [Cop(Cadda,
                           [meths; lsl_const (Cvar mi) log2_size_addr dbg],
                           dbg)],
@@ -3184,12 +3186,12 @@ let send_function arity =
     let cached_pos = Cvar cached in
     let tag_pos = Cop(Cadda, [Cop (Cadda, [cached_pos; Cvar meths], dbg);
                               Cconst_int(3*size_addr-1)], dbg) in
-    let tag' = Cop(Cload (Word_int, Mutable), [tag_pos], dbg) in
+    let tag' = Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [tag_pos], dbg) in
     Clet (
     meths, get_mut_field obj (Cconst_int 0) dbg,
     Clet (
     cached,
-      Cop(Cand, [Cop(Cload (Word_int, Mutable), [cache], dbg); mask], dbg),
+      Cop(Cand, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [cache], dbg); mask], dbg),
     Clet (
     real,
     Cifthenelse(Cop(Ccmpa Cne, [tag'; tag], dbg),
@@ -3416,7 +3418,7 @@ let entry_point namelist =
   let incr_global_inited =
     Cop(Cstore (Word_int, Assignment),
         [Cconst_symbol "caml_globals_inited";
-         Cop(Caddi, [Cop(Cload (Word_int, Mutable),
+         Cop(Caddi, [Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true},
                        [Cconst_symbol "caml_globals_inited"], dbg);
                      Cconst_int 1], dbg)], dbg) in
   let body =

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -250,13 +250,13 @@ method! select_operation op args dbg =
 
 method select_floatarith regular_op reversed_op mem_op mem_rev_op args =
   match args with
-    [arg1; Cop(Cload (chunk, _), [loc2], _)] ->
-      let (addr, arg2) = self#select_addressing chunk loc2 in
-      (Ispecific(Ifloatarithmem(chunk_double chunk, mem_op, addr)),
+    [arg1; Cop(Cload {memory_chunk}, [loc2], _)] ->
+      let (addr, arg2) = self#select_addressing memory_chunk loc2 in
+      (Ispecific(Ifloatarithmem(chunk_double memory_chunk, mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload (chunk, _), [loc1], _); arg2] ->
-      let (addr, arg1) = self#select_addressing chunk loc1 in
-      (Ispecific(Ifloatarithmem(chunk_double chunk, mem_rev_op, addr)),
+  | [Cop(Cload {memory_chunk}, [loc1], _); arg2] ->
+      let (addr, arg1) = self#select_addressing memory_chunk loc1 in
+      (Ispecific(Ifloatarithmem(chunk_double memory_chunk, mem_rev_op, addr)),
                  [arg2; arg1])
   | [arg1; arg2] ->
       (* Evaluate bigger subexpression first to minimize stack usage.
@@ -292,10 +292,10 @@ method select_push exp =
   | Cconst_pointer n -> (Ispecific(Ipush_int(Nativeint.of_int n)), Ctuple [])
   | Cconst_natpointer n -> (Ispecific(Ipush_int n), Ctuple [])
   | Cconst_symbol s -> (Ispecific(Ipush_symbol s), Ctuple [])
-  | Cop(Cload ((Word_int | Word_val as chunk), _), [loc], _) ->
+  | Cop(Cload {memory_chunk = (Word_int | Word_val) as chunk}, [loc], _) ->
       let (addr, arg) = self#select_addressing chunk loc in
       (Ispecific(Ipush_load addr), arg)
-  | Cop(Cload (Double_u, _), [loc], _) ->
+  | Cop(Cload {memory_chunk = Double_u}, [loc], _) ->
       let (addr, arg) = self#select_addressing Double_u loc in
       (Ispecific(Ipush_load_float addr), arg)
   | _ -> (Ispecific(Ipush), exp)

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -65,7 +65,7 @@ let operation d = function
     match mutability with
     | Asttypes.Immutable -> Printf.sprintf "load %s" (chunk memory_chunk)
     | Asttypes.Mutable   -> Printf.sprintf "load_mut %s" (chunk memory_chunk) )
-  | Cloadmut -> "load_mut_rb"
+  | Cloadmut {is_atomic=_} -> "load_mut_rb"
   | Calloc -> "alloc" ^ Debuginfo.to_string d
   | Cstore (c, init) ->
     let init =

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -64,8 +64,8 @@ let operation d = function
   | Cload {memory_chunk; mutability} -> (
     match mutability with
     | Asttypes.Immutable -> Printf.sprintf "load %s" (chunk memory_chunk)
-    | Asttypes.Mutable   -> Printf.sprintf "load_mut %s" (chunk memory_chunk) )
-  | Cloadmut {is_atomic=_} -> "load_mut_rb"
+    | Asttypes.Mutable   -> Printf.sprintf "load_mut_imm %s" (chunk memory_chunk) )
+  | Cloadmut {is_atomic=_} -> "load_mut_ptr"
   | Calloc -> "alloc" ^ Debuginfo.to_string d
   | Cstore (c, init) ->
     let init =

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -61,8 +61,10 @@ let operation d = function
   | Capply _ty -> "app" ^ Debuginfo.to_string d
   | Cextcall(lbl, _ty, _alloc, _) ->
       Printf.sprintf "extcall \"%s\"%s" lbl (Debuginfo.to_string d)
-  | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load %s" (chunk c)
-  | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load_mut %s" (chunk c)
+  | Cload {memory_chunk; mutability} -> (
+    match mutability with
+    | Asttypes.Immutable -> Printf.sprintf "load %s" (chunk memory_chunk)
+    | Asttypes.Mutable   -> Printf.sprintf "load_mut %s" (chunk memory_chunk) )
   | Cloadmut -> "load_mut_rb"
   | Calloc -> "alloc" ^ Debuginfo.to_string d
   | Cstore (c, init) ->

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -56,7 +56,7 @@ let oper_result_type = function
       | Single | Double | Double_u -> typ_float
       | _ -> typ_int
       end
-  | Cloadmut -> typ_val
+  | Cloadmut {is_atomic=_} -> typ_val
   | Calloc -> typ_val
   | Cstore (_c, _) -> typ_void
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi |
@@ -295,7 +295,7 @@ method is_simple_expr = function
   | Cop(op, args, _) ->
       begin match op with
         (* The following may have side effects *)
-      | Capply _ | Cextcall _ | Cloadmut | Calloc | Cstore _ | Craise _ -> false
+      | Capply _ | Cextcall _ | Cloadmut {is_atomic=_} | Calloc | Cstore _ | Craise _ -> false
         (* The remaining operations are simple if their args are *)
       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
@@ -339,7 +339,7 @@ method effects_of exp =
       | Cstore _ -> EC.effect_only Effect.Arbitrary
       | Craise _ | Ccheckbound -> EC.effect_only Effect.Raise
       | Cload {mutability = Asttypes.Immutable} -> EC.none
-      | Cloadmut | Cload {mutability = Asttypes.Mutable} ->
+      | Cloadmut {is_atomic=_} | Cload {mutability = Asttypes.Mutable} ->
           EC.coeffect_only Coeffect.Read_mutable
       | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor | Cxor
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
@@ -420,10 +420,10 @@ method select_operation op args _dbg =
       | Some label_after -> label_after
     in
     Iextcall { func; alloc; label_after; stack_ofs = -1}, args
-  | (Cload {memory_chunk=chunk; mutability=_mut; is_atomic=true}, [arg]) ->
+  | (Cload {memory_chunk=chunk; mutability=_mut; is_atomic=_}, [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in
       (Iload(chunk, addr), [eloc])
-  | (Cloadmut, _) -> (Iloadmut, args)
+  | (Cloadmut {is_atomic=_}, _) -> (Iloadmut, args)
   | (Cstore (chunk, init), [arg1; arg2]) ->
       let (addr, eloc) = self#select_addressing chunk arg1 in
       let is_assign =

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -50,13 +50,13 @@ let env_empty = {
 let oper_result_type = function
     Capply ty -> ty
   | Cextcall(_s, ty, _alloc, _) -> ty
-  | Cload {memory_chunk = c; _;} ->
-      begin match c with
+  | Cload {memory_chunk} ->
+      begin match memory_chunk with
       | Word_val -> typ_val
       | Single | Double | Double_u -> typ_float
       | _ -> typ_int
       end
-  | Cloadmut {is_atomic=_} -> typ_val
+  | Cloadmut _ -> typ_val
   | Calloc -> typ_val
   | Cstore (_c, _) -> typ_void
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi |
@@ -295,7 +295,7 @@ method is_simple_expr = function
   | Cop(op, args, _) ->
       begin match op with
         (* The following may have side effects *)
-      | Capply _ | Cextcall _ | Cloadmut {is_atomic=_} | Calloc | Cstore _ | Craise _ -> false
+      | Capply _ | Cextcall _ | Cloadmut _ | Calloc | Cstore _ | Craise _ -> false
         (* The remaining operations are simple if their args are *)
       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
@@ -339,7 +339,7 @@ method effects_of exp =
       | Cstore _ -> EC.effect_only Effect.Arbitrary
       | Craise _ | Ccheckbound -> EC.effect_only Effect.Raise
       | Cload {mutability = Asttypes.Immutable} -> EC.none
-      | Cloadmut {is_atomic=_} | Cload {mutability = Asttypes.Mutable} ->
+      | Cloadmut _ | Cload {mutability = Asttypes.Mutable} ->
           EC.coeffect_only Coeffect.Read_mutable
       | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor | Cxor
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
@@ -420,10 +420,10 @@ method select_operation op args _dbg =
       | Some label_after -> label_after
     in
     Iextcall { func; alloc; label_after; stack_ofs = -1}, args
-  | (Cload {memory_chunk=chunk; mutability=_mut; is_atomic=_}, [arg]) ->
-      let (addr, eloc) = self#select_addressing chunk arg in
-      (Iload(chunk, addr), [eloc])
-  | (Cloadmut {is_atomic=_}, _) -> (Iloadmut, args)
+  | (Cload {memory_chunk}, [arg]) ->
+      let (addr, eloc) = self#select_addressing memory_chunk arg in
+      (Iload(memory_chunk, addr), [eloc])
+  | (Cloadmut _, _) -> (Iloadmut, args)
   | (Cstore (chunk, init), [arg1; arg2]) ->
       let (addr, eloc) = self#select_addressing chunk arg1 in
       let is_assign =

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -54,6 +54,9 @@ let reset ~spacetime_node_ident:ident ~function_label =
   current_function_label := function_label;
   reverse_shape := []
 
+let mk_load_mut memory_chunk = let open Cmm in
+  Cload {memory_chunk; mutability=Asttypes.Mutable; is_atomic=false}
+
 let code_for_function_prologue ~function_name ~node_hole =
   let node = Ident.create "node" in
   let new_node = Ident.create "new_node" in
@@ -89,7 +92,7 @@ let code_for_function_prologue ~function_name ~node_hole =
         body)
   in
   let pc = Ident.create "pc" in
-  Clet (node, Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar node_hole], dbg),
+  Clet (node, Cop (mk_load_mut Word_int, [Cvar node_hole], dbg),
     Clet (must_allocate_node,
       Cop (Cand, [Cvar node; Cconst_int 1], dbg),
       Cifthenelse (
@@ -105,7 +108,7 @@ let code_for_function_prologue ~function_name ~node_hole =
               ],
               dbg)),
             Clet (new_node,
-              Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar node_hole], dbg),
+              Cop (mk_load_mut Word_int, [Cvar node_hole], dbg),
               if no_tail_calls then Cvar new_node
               else
                 Cifthenelse (
@@ -149,7 +152,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
       Cconst_int offset_into_node;
     ], dbg),
     Clet (existing_profinfo,
-        Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar address_of_profinfo],
+        Cop (mk_load_mut Word_int, [Cvar address_of_profinfo],
           dbg),
       Clet (profinfo,
         Cifthenelse (
@@ -157,7 +160,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
           Cvar existing_profinfo,
           generate_new_profinfo),
         Clet (existing_count,
-          Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [
+          Cop (mk_load_mut Word_int, [
             Cop (Caddi,
               [Cvar address_of_profinfo; Cconst_int Arch.size_addr], dbg)
           ], dbg),
@@ -232,7 +235,7 @@ let code_for_call ~node ~callee ~is_tail ~label =
         Clet (count_addr,
           Cop (Caddi, [Cvar place_within_node; Cconst_int Arch.size_addr], dbg),
           Clet (count,
-            Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar count_addr], dbg),
+            Cop (mk_load_mut Word_int, [Cvar count_addr], dbg),
             Csequence (
               Cop (Cstore (Word_int, Lambda.Assignment),
                 (* Adding 2 really means adding 1; the count is encoded

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -89,7 +89,7 @@ let code_for_function_prologue ~function_name ~node_hole =
         body)
   in
   let pc = Ident.create "pc" in
-  Clet (node, Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar node_hole], dbg),
+  Clet (node, Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar node_hole], dbg),
     Clet (must_allocate_node,
       Cop (Cand, [Cvar node; Cconst_int 1], dbg),
       Cifthenelse (
@@ -105,7 +105,7 @@ let code_for_function_prologue ~function_name ~node_hole =
               ],
               dbg)),
             Clet (new_node,
-              Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar node_hole], dbg),
+              Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar node_hole], dbg),
               if no_tail_calls then Cvar new_node
               else
                 Cifthenelse (
@@ -149,7 +149,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
       Cconst_int offset_into_node;
     ], dbg),
     Clet (existing_profinfo,
-        Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar address_of_profinfo],
+        Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar address_of_profinfo],
           dbg),
       Clet (profinfo,
         Cifthenelse (
@@ -157,7 +157,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
           Cvar existing_profinfo,
           generate_new_profinfo),
         Clet (existing_count,
-          Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [
+          Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [
             Cop (Caddi,
               [Cvar address_of_profinfo; Cconst_int Arch.size_addr], dbg)
           ], dbg),
@@ -232,7 +232,7 @@ let code_for_call ~node ~callee ~is_tail ~label =
         Clet (count_addr,
           Cop (Caddi, [Cvar place_within_node; Cconst_int Arch.size_addr], dbg),
           Clet (count,
-            Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar count_addr], dbg),
+            Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false}, [Cvar count_addr], dbg),
             Csequence (
               Cop (Cstore (Word_int, Lambda.Assignment),
                 (* Adding 2 really means adding 1; the count is encoded

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -89,7 +89,7 @@ let code_for_function_prologue ~function_name ~node_hole =
         body)
   in
   let pc = Ident.create "pc" in
-  Clet (node, Cop (Cload (Word_int, Asttypes.Mutable), [Cvar node_hole], dbg),
+  Clet (node, Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar node_hole], dbg),
     Clet (must_allocate_node,
       Cop (Cand, [Cvar node; Cconst_int 1], dbg),
       Cifthenelse (
@@ -105,7 +105,7 @@ let code_for_function_prologue ~function_name ~node_hole =
               ],
               dbg)),
             Clet (new_node,
-              Cop (Cload (Word_int, Asttypes.Mutable), [Cvar node_hole], dbg),
+              Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar node_hole], dbg),
               if no_tail_calls then Cvar new_node
               else
                 Cifthenelse (
@@ -149,7 +149,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
       Cconst_int offset_into_node;
     ], dbg),
     Clet (existing_profinfo,
-        Cop (Cload (Word_int, Asttypes.Mutable), [Cvar address_of_profinfo],
+        Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar address_of_profinfo],
           dbg),
       Clet (profinfo,
         Cifthenelse (
@@ -157,7 +157,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
           Cvar existing_profinfo,
           generate_new_profinfo),
         Clet (existing_count,
-          Cop (Cload (Word_int, Asttypes.Mutable), [
+          Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [
             Cop (Caddi,
               [Cvar address_of_profinfo; Cconst_int Arch.size_addr], dbg)
           ], dbg),
@@ -232,7 +232,7 @@ let code_for_call ~node ~callee ~is_tail ~label =
         Clet (count_addr,
           Cop (Caddi, [Cvar place_within_node; Cconst_int Arch.size_addr], dbg),
           Clet (count,
-            Cop (Cload (Word_int, Asttypes.Mutable), [Cvar count_addr], dbg),
+            Cop (Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true}, [Cvar count_addr], dbg),
             Csequence (
               Cop (Cstore (Word_int, Lambda.Assignment),
                 (* Adding 2 really means adding 1; the count is encoded

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -73,7 +73,7 @@ module Make(I:I) = struct
   let mk_let_cell id str ind body =
     let dbg = Debuginfo.none in
     let cell =
-      Cop(Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true},
+      Cop(Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=false},
         [Cop(Cadda,[str;Cconst_int(Arch.size_int*ind)], dbg)],
         dbg) in
     Clet(id, cell, body)

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -73,7 +73,7 @@ module Make(I:I) = struct
   let mk_let_cell id str ind body =
     let dbg = Debuginfo.none in
     let cell =
-      Cop(Cload (Word_int, Asttypes.Mutable),
+      Cop(Cload {memory_chunk=Word_int; mutability=Asttypes.Mutable; is_atomic=true},
         [Cop(Cadda,[str;Cconst_int(Arch.size_int*ind)], dbg)],
         dbg) in
     Clet(id, cell, body)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -446,7 +446,7 @@ let comp_primitive p sz args =
   | Pbswap16 -> Kccall("caml_bswap16", 1)
   | Pbbswap(bi) -> comp_bint_primitive bi "bswap" args
   | Pint_as_pointer -> Kccall("caml_int_as_pointer", 1)
-  | Patomic_load -> Kccall("caml_atomic_load", 1)
+  | Patomic_load {immediate_or_pointer=_} -> Kccall("caml_atomic_load", 1)
   | Patomic_exchange -> Kccall("caml_atomic_exchange", 2);
   | Patomic_cas -> Kccall("caml_atomic_cas", 3);
   | Patomic_fetch_add -> Kccall("caml_atomic_fetch_add", 2);

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -446,7 +446,7 @@ let comp_primitive p sz args =
   | Pbswap16 -> Kccall("caml_bswap16", 1)
   | Pbbswap(bi) -> comp_bint_primitive bi "bswap" args
   | Pint_as_pointer -> Kccall("caml_int_as_pointer", 1)
-  | Patomic_load {immediate_or_pointer=_} -> Kccall("caml_atomic_load", 1)
+  | Patomic_load _ -> Kccall("caml_atomic_load", 1)
   | Patomic_exchange -> Kccall("caml_atomic_exchange", 2);
   | Patomic_cas -> Kccall("caml_atomic_cas", 3);
   | Patomic_fetch_add -> Kccall("caml_atomic_fetch_add", 2);

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -155,7 +155,7 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
   (* Atomic operations *)
-  | Patomic_load
+  | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange
   | Patomic_cas
   | Patomic_fetch_add

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -163,7 +163,7 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
   (* Atomic operations *)
-  | Patomic_load
+  | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange
   | Patomic_cas
   | Patomic_fetch_add

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -336,7 +336,7 @@ let primitive ppf = function
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
-  | Patomic_load -> fprintf ppf "atomic_load"
+  | Patomic_load {immediate_or_pointer=_} -> fprintf ppf "atomic_load"
   | Patomic_exchange -> fprintf ppf "atomic_exchange"
   | Patomic_cas -> fprintf ppf "atomic_cas"
   | Patomic_fetch_add -> fprintf ppf "atomic_fetch_add"
@@ -443,7 +443,7 @@ let name_of_primitive = function
   | Pbswap16 -> "Pbswap16"
   | Pbbswap _ -> "Pbbswap"
   | Pint_as_pointer -> "Pint_as_pointer"
-  | Patomic_load -> "Patomic_load"
+  | Patomic_load {immediate_or_pointer=_} -> "Patomic_load"
   | Patomic_exchange -> "Patomic_exchange"
   | Patomic_cas -> "Patomic_cas"
   | Patomic_fetch_add -> "Patomic_fetch_add"

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -336,7 +336,10 @@ let primitive ppf = function
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
-  | Patomic_load {immediate_or_pointer=_} -> fprintf ppf "atomic_load"
+  | Patomic_load {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> fprintf ppf "atomic_load_imm"
+        | Pointer -> fprintf ppf "atomic_load_ptr")
   | Patomic_exchange -> fprintf ppf "atomic_exchange"
   | Patomic_cas -> fprintf ppf "atomic_cas"
   | Patomic_fetch_add -> fprintf ppf "atomic_fetch_add"
@@ -443,7 +446,10 @@ let name_of_primitive = function
   | Pbswap16 -> "Pbswap16"
   | Pbbswap _ -> "Pbbswap"
   | Pint_as_pointer -> "Pint_as_pointer"
-  | Patomic_load {immediate_or_pointer=_} -> "Patomic_load"
+  | Patomic_load {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> "atomic_load_imm"
+        | Pointer -> "atomic_load_ptr")
   | Patomic_exchange -> "Patomic_exchange"
   | Patomic_cas -> "Patomic_cas"
   | Patomic_fetch_add -> "Patomic_fetch_add"

--- a/bytecomp/semantics_of_primitives.ml
+++ b/bytecomp/semantics_of_primitives.ml
@@ -125,7 +125,7 @@ let for_primitive (prim : Lambda.primitive) =
   | Psetfield_computed _
   | Psetfloatfield _
   | Psetglobal _
-  | Patomic_load
+  | Patomic_load {immediate_or_pointer = _}
   | Patomic_exchange
   | Patomic_cas
   | Patomic_fetch_add

--- a/bytecomp/semantics_of_primitives.ml
+++ b/bytecomp/semantics_of_primitives.ml
@@ -125,7 +125,7 @@ let for_primitive (prim : Lambda.primitive) =
   | Psetfield_computed _
   | Psetfloatfield _
   | Psetglobal _
-  | Patomic_load {immediate_or_pointer = _}
+  | Patomic_load _
   | Patomic_exchange
   | Patomic_cas
   | Patomic_fetch_add

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -360,7 +360,7 @@ let primitives_table = create_hashtable 57 [
   "%bswap_int64", Pbbswap(Pint64);
   "%bswap_native", Pbbswap(Pnativeint);
   "%int_as_pointer", Pint_as_pointer;
-  "%atomic_load", Patomic_load;
+  "%atomic_load", Patomic_load {immediate_or_pointer=Pointer};
   "%atomic_exchange", Patomic_exchange;
   "%atomic_cas", Patomic_cas;
   "%atomic_fetch_add", Patomic_fetch_add;

--- a/testsuite/tests/asmcomp/parsecmm.mly
+++ b/testsuite/tests/asmcomp/parsecmm.mly
@@ -206,16 +206,16 @@ expr:
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
                 { unbind_ident $5; Ctrywith($3, $5, $6) }
   | LPAREN VAL expr expr RPAREN
-      { Cop(Cload {memory_chunk=Word_val; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_addr],
+      { Cop(Cload {memory_chunk=Word_val; mutability=Mutable; is_atomic=false}, [access_array $3 $4 Arch.size_addr],
           debuginfo ()) }
   | LPAREN ADDRAREF expr expr RPAREN
-      { Cop(Cload {memory_chunk=Word_val; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_addr],
+      { Cop(Cload {memory_chunk=Word_val; mutability=Mutable; is_atomic=false}, [access_array $3 $4 Arch.size_addr],
           Debuginfo.none) }
   | LPAREN INTAREF expr expr RPAREN
-      { Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_int],
+      { Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=false}, [access_array $3 $4 Arch.size_int],
           Debuginfo.none) }
   | LPAREN FLOATAREF expr expr RPAREN
-      { Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_float],
+      { Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=false}, [access_array $3 $4 Arch.size_float],
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
       { Cop(Cstore (Word_val, Assignment),
@@ -257,7 +257,7 @@ chunk:
   | VAL                         { Word_val }
 ;
 unaryop:
-    LOAD chunk                  { Cload {memory_chunk=$2; mutability=Mutable; is_atomic=true} }
+    LOAD chunk                  { Cload {memory_chunk=$2; mutability=Mutable; is_atomic=false} }
   | FLOATOFINT                  { Cfloatofint }
   | INTOFFLOAT                  { Cintoffloat }
   | RAISE                       { Craise $1 }

--- a/testsuite/tests/asmcomp/parsecmm.mly
+++ b/testsuite/tests/asmcomp/parsecmm.mly
@@ -206,16 +206,16 @@ expr:
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
                 { unbind_ident $5; Ctrywith($3, $5, $6) }
   | LPAREN VAL expr expr RPAREN
-      { Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+      { Cop(Cload {memory_chunk=Word_val; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_addr],
           debuginfo ()) }
   | LPAREN ADDRAREF expr expr RPAREN
-      { Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+      { Cop(Cload {memory_chunk=Word_val; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_addr],
           Debuginfo.none) }
   | LPAREN INTAREF expr expr RPAREN
-      { Cop(Cload (Word_int, Mutable), [access_array $3 $4 Arch.size_int],
+      { Cop(Cload {memory_chunk=Word_int; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_int],
           Debuginfo.none) }
   | LPAREN FLOATAREF expr expr RPAREN
-      { Cop(Cload (Double_u, Mutable), [access_array $3 $4 Arch.size_float],
+      { Cop(Cload {memory_chunk=Double_u; mutability=Mutable; is_atomic=true}, [access_array $3 $4 Arch.size_float],
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
       { Cop(Cstore (Word_val, Assignment),
@@ -257,7 +257,7 @@ chunk:
   | VAL                         { Word_val }
 ;
 unaryop:
-    LOAD chunk                  { Cload ($2, Mutable) }
+    LOAD chunk                  { Cload {memory_chunk=$2; mutability=Mutable; is_atomic=true} }
   | FLOATOFINT                  { Cfloatofint }
   | INTOFFLOAT                  { Cintoffloat }
   | RAISE                       { Craise $1 }


### PR DESCRIPTION
This PR aims to fix #237. `Atomic.get` is a library function that provides atomic reads across domains. On `x86`, these atomic reads emit an external function call - `caml_atomic_load`. This function loads a value and emits a `read_barrier` to prevent re-ordering from happening. 

The external call is unnecessary, and on `x86`, can be translated to plain loads.

TODO: 
- [x] Extend `Patomic_load` with an `immediate_or_pointer` field
- [x] Modify `Cload` and `Cloadmut` to use inline records instead of tuples
- [x] Extend `Cload` and `Cloadmut` with `is_atomic` field
- [x] Translate `Patomic_load` to `Cload {}` or `Cload {}`
- [x] Emit `Iloadmut` instead of `caml_atomic_load`

# Changes
#### Extending `Patomic_load` with an `immediate_or_pointer` field
`Patomic_load` is a lambda op, which has been extended with a field to denote whether that load is to a value or an immediate.
```
| Patomic_load
```
to
```
| Patomic_load of {immediate_or_pointer : immediate_or_pointer}
````

#### Changing `Cload` and `Cloadmut` to use records instead of tuples

`Cload` and `Cloadmut` are two `cmm` operations defined as - 

```ocaml
| Cload of memory_chunk * Asttypes.mutable_flag
| Cloadmut
```

This has now been modified to be - 
```ocaml
| Cload of {memory_chunk: memory_chunk; mutability: Asttypes.mutable_flag; is_atomic: bool}
| Cloadmut of {is_atomic:bool}
```

All occurring values and usage in pattern matching has been updated to the new representation

#### Emitting `Cload` or `Cloadmut` from `Patomic_load`
The `cmmgen.ml` file emits cmm from lambda expressions. For this, the pattern match has been modified as - 

```ocaml
| Patomic_load ->
     Cop (Cextcall("caml_atomic_load", typ_val, true, None), [transl env arg], dbg)
```
to
```ocaml
  | Patomic_load {immediate_or_pointer} ->
      let ptr = transl env arg
      in
      ( match immediate_or_pointer with
        | Immediate -> Cop (Cload {memory_chunk=Word_int ; mutability=Mutable ; is_atomic=true} , [ptr; Cconst_int 0], dbg)
        | Pointer -> Cop (Cloadmut {is_atomic=true}, [ptr; Cconst_int 0], dbg) )
```

#### Emit Iloadmut instead of caml_atomic_load
In `selectgen.ml`, the `Cload` and `Cloadmut` are translated to `iload` and `iloadmut`. In x86, the `is_atomic` param is ignored.

