### PR TITLE
Fix #252 by making atomic exchange always call the write barrier.

### DIFF
--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -253,8 +253,8 @@ CAMLprim value caml_atomic_exchange (value ref, value v)
     /* See Note [MM] above */
     atomic_thread_fence(memory_order_acquire);
     ret = atomic_exchange(Op_atomic_val(ref), v);
-    write_barrier(ref, 0, ret, v);
   }
+  write_barrier(ref, 0, ret, v);
   return ret;
 }
 

--- a/testsuite/tests/parallel/atomics.ml
+++ b/testsuite/tests/parallel/atomics.ml
@@ -1,3 +1,15 @@
+type u = U of unit
+let () =
+  (* See https://github.com/ocaml-multicore/ocaml-multicore/issues/252 *)
+  let make_cell (x : unit) : u Atomic.t =
+    let cell = Atomic.make (U x) in
+    Atomic.set cell (U x) ;
+    cell in
+  (* the error shows up with an array of length 256 or larger *)
+  let a = Array.make 256 (make_cell ()) in
+  ignore (Sys.opaque_identity a)
+
+
 let test_fetch_add () =
   let ndoms = 4 in
   let count = 10000 in


### PR DESCRIPTION
`caml_atomic_exchange` didn't call the write barrier if the atomic being modified was young. But because of the young-young table, we need to do work in the write barrier even when mutating young objects.

I suspect this isn't the only codepath that has this bug: the assumption that the write barrier does no work when young values are modified is easy to make, because it's true in stock OCaml.