### PR TITLE
#129 Added a longjmp context to the newly created domain, to avoid bringing down the runtime 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 *.out.dSYM
 *.swp
 _ocamltest
+.vscode
 
 # local to root directory
 

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -2,9 +2,12 @@ type 'a t
 (** A domain of type ['a t] runs independently, eventually producing a
     result of type 'a, or an exception *)
 
+exception Spawn_failure of string
 val spawn : (unit -> 'a) -> 'a t
 (** [spawn f] creates a new domain that runs in parallel with the
-    current domain. *)
+    current domain.
+    Raises Spawn_failure if an error occurs during the creation
+    of the domain *)
 
 val join : 'a t -> 'a
 (** [join d] blocks until domain [d] runs to completion.


### PR DESCRIPTION
I thought I'd take a look at issue #129.

I've created a commit causes any exceptions raised during domain initialization, to get back to the parent domain, get raised from the call to Spawn.
I suspect there's more that needs to be done when the longjmp occurs on the fresh domain to clean up, and I haven't really looked at what needs to be done for native code, but I'm hoping that I'm on the right track.
There are also (currently) no tests, as I'm unsure how to trigger an exception/OOM without making changes to the code solely for testing (I wrote the change with a hard coded OOM in the create_domain() function)