### PR TITLE
Inline loads specialized

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2097,7 +2097,7 @@ and transl_prim_1 env p arg dbg =
       let ptr = transl env arg
       in
       ( match immediate_or_pointer with
-        | Immediate -> Cop (Cload {memory_chunk=Word_int ; mutability=Mutable ; is_atomic=true} , [ptr; Cconst_int 0], dbg)
+        | Immediate -> Cop (Cload {memory_chunk=Word_int ; mutability=Mutable ; is_atomic=true} , [ptr], dbg)
         | Pointer -> Cop (Cloadmut {is_atomic=true}, [ptr; Cconst_int 0], dbg) )
   | prim ->
       fatal_errorf "Cmmgen.transl_prim_1: %a" Printlambda.primitive prim

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -464,7 +464,7 @@ let specialize_primitive p env ty ~has_constant_constructor =
     | (Pmakeblock(tag, mut, None), fields) ->
         let shape = List.map (Typeopt.value_kind env) fields in
         Pmakeblock(tag, mut, Some shape)
-    | (Patomic_load _, _) ->
+    | (Patomic_load { immediate_or_pointer = Pointer }, _) ->
         let is_int = match is_function_type env ty with
           | None -> Pointer
           | Some (_p1, rhs) -> maybe_pointer_type env rhs in

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -464,6 +464,11 @@ let specialize_primitive p env ty ~has_constant_constructor =
     | (Pmakeblock(tag, mut, None), fields) ->
         let shape = List.map (Typeopt.value_kind env) fields in
         Pmakeblock(tag, mut, Some shape)
+    | (Patomic_load _, _) ->
+        let is_int = match is_function_type env ty with
+          | None -> Pointer
+          | Some (_p1, rhs) -> maybe_pointer_type env rhs in
+        Patomic_load {immediate_or_pointer = is_int}
     | _ -> p
 
 (* Eta-expand a primitive *)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -1,10 +1,11 @@
 type 'a t
 
-val make : 'a -> 'a t
-val get : 'a t -> 'a
+external make : 'a -> 'a t = "%makemutable"
+external get : 'a t -> 'a = "%atomic_load"
+external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
+external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"
+external fetch_and_add : int t -> int -> int = "%atomic_fetch_add"
+
 val set : 'a t -> 'a -> unit
-val exchange : 'a t -> 'a -> 'a
-val compare_and_set : 'a t -> 'a -> 'a -> bool
-val fetch_and_add : int t -> int -> int
 val incr : int t -> unit
 val decr : int t -> unit


### PR DESCRIPTION
Adding an entry in `translcore.ml` to specialize loads based on whether the load is to an `immediate` or `pointer`