### PR TITLE
Fixes for error handling during domain creation 

### DIFF
--- a/byterun/caml/domain.h
+++ b/byterun/caml/domain.h
@@ -19,7 +19,7 @@ struct domain {
    CAMLunlikely((uintnat)(dom_st)->young_ptr < (dom_st)->young_limit))
 
 asize_t caml_norm_minor_heap_size (intnat);
-void caml_reallocate_minor_heap(asize_t);
+int caml_reallocate_minor_heap(asize_t);
 
 void caml_handle_gc_interrupt(void);
 

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -29,7 +29,7 @@ intnat caml_major_collection_slice (intnat, intnat* left /* out */);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);
 uintnat caml_get_num_domains_to_mark(void);
-void caml_init_major_gc(caml_domain_state*);
+int caml_init_major_gc(caml_domain_state*);
 void caml_teardown_major_gc(void);
 void caml_darken(void*, value, value* ignored);
 void caml_darken_cont(value);

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -37,6 +37,7 @@ extern "C" {
 #endif
 
 CAMLextern value caml_alloc_shr (mlsize_t wosize, tag_t);
+CAMLextern value caml_alloc_shr_noexc(mlsize_t wosize, tag_t);
 #ifdef WITH_PROFINFO
 CAMLextern value caml_alloc_shr_with_profinfo (mlsize_t, tag_t, intnat);
 CAMLextern value caml_alloc_shr_preserving_profinfo (mlsize_t, tag_t,
@@ -567,6 +568,7 @@ struct caml__roots_block {
    with [caml_read_root] and [caml_modify_root]. */
 
 CAMLextern caml_root caml_create_root (value);
+CAMLextern caml_root caml_create_root_noexc(value);
 
 /* [caml_delete_root] deletes a root created by caml_create_root */
 

--- a/byterun/caml/signals.h
+++ b/byterun/caml/signals.h
@@ -30,7 +30,7 @@ extern "C" {
 CAMLextern intnat volatile caml_signals_are_pending;
 CAMLextern intnat volatile caml_pending_signals[];
 CAMLextern int volatile caml_something_to_do;
-void caml_init_signal_stack(void);
+int caml_init_signal_stack(void);
 void caml_free_signal_stack(void);
 void caml_init_signal_handling(void);
 /* </private> */

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -29,12 +29,13 @@ static struct stack_info* alloc_stack_noexc(mlsize_t wosize, value hval, value h
   CAML_STATIC_ASSERT(sizeof(struct stack_info) % sizeof(value) == 0);
   CAML_STATIC_ASSERT(sizeof(struct stack_handler) % sizeof(value) == 0);
 
-  stack = caml_stat_alloc(sizeof(struct stack_info) +
+  stack = caml_stat_alloc_noexc(sizeof(struct stack_info) +
                           sizeof(value) * wosize +
                           8 /* for alignment */ +
                           sizeof(struct stack_handler));
-  if (stack == NULL)
+  if (stack == NULL) {
     return NULL;
+  }
 
   /* Ensure 16-byte alignment because some architectures require it */
   hand = (struct stack_handler*)
@@ -316,7 +317,6 @@ struct stack_info* caml_alloc_main_stack (uintnat init_size)
 {
   struct stack_info* stk =
     alloc_stack_noexc(init_size, Val_unit, Val_unit,  Val_unit);
-  if (!stk) caml_raise_out_of_memory();
   return stk;
 }
 

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -373,7 +373,8 @@ CAMLprim value caml_final_release (value unit)
 struct caml_final_info* caml_alloc_final_info ()
 {
   struct caml_final_info* f =
-    caml_stat_alloc (sizeof(struct caml_final_info));
-  memset (f, 0, sizeof(struct caml_final_info));
+    caml_stat_alloc_noexc (sizeof(struct caml_final_info));
+  if(f != NULL)
+    memset (f, 0, sizeof(struct caml_final_info));
   return f;
 }

--- a/byterun/globroots.c
+++ b/byterun/globroots.c
@@ -62,6 +62,24 @@ CAMLexport caml_root caml_create_root(value init)
 
   CAMLreturnT(caml_root, (caml_root)v);
 }
+CAMLexport caml_root caml_create_root_noexc(value init)
+{
+  CAMLparam1(init);
+  CAMLlocal1(v);
+  v = caml_alloc_shr_noexc(3, 0);
+  if(v == (value)NULL) {
+    CAMLreturnT(caml_root, (caml_root)v);
+  }
+  caml_initialize_field(v, 0, init);
+  caml_initialize_field(v, 1, Val_int(1));
+
+  caml_plat_lock(&roots_mutex);
+  caml_initialize_field(v, 2, roots_all);
+  roots_all = v;
+  caml_plat_unlock(&roots_mutex);
+
+  CAMLreturnT(caml_root, (caml_root)v);
+}
 
 CAMLexport void caml_delete_root(caml_root root)
 {

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -81,9 +81,10 @@ static void clear_table (struct generic_table *tbl)
 
 struct caml_minor_tables* caml_alloc_minor_tables()
 {
-  struct caml_minor_tables* r =
-    caml_stat_alloc(sizeof(struct caml_minor_tables));
-  memset(r, 0, sizeof(*r));
+  struct caml_minor_tables *r =
+      caml_stat_alloc_noexc(sizeof(struct caml_minor_tables));
+  if(r != NULL)
+    memset(r, 0, sizeof(*r));
   return r;
 }
 
@@ -104,7 +105,9 @@ void caml_set_minor_heap_size (asize_t wsize)
   struct caml_minor_tables *r = domain_state->minor_tables;
   if (domain_state->young_ptr != domain_state->young_end) caml_minor_collection ();
 
-  caml_reallocate_minor_heap(wsize);
+  if(caml_reallocate_minor_heap(wsize) < 0) {
+    caml_fatal_error("Fatal error: No memory for minor heap");
+  }
 
   reset_table ((struct generic_table *)&r->major_ref);
   reset_table ((struct generic_table *)&r->minor_ref);

--- a/byterun/platform.c
+++ b/byterun/platform.c
@@ -180,7 +180,6 @@ void* caml_mem_map(uintnat size, uintnat alignment, int reserve_only)
   caml_mem_unmap((void*)aligned_end, (base + alloc_sz) - aligned_end);
   return (void*)aligned_start;
 }
-
 static void* map_fixed(void* mem, uintnat size, int prot)
 {
   if (mmap((void*)mem, size, prot,

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -79,18 +79,20 @@ struct caml_heap_state* caml_init_shared_heap() {
   int i;
   struct caml_heap_state* heap;
 
-  heap = caml_stat_alloc(sizeof(struct caml_heap_state));
-  heap->free_pools = 0;
-  heap->num_free_pools = 0;
-  for (i = 0; i<NUM_SIZECLASSES; i++) {
-    heap->avail_pools[i] = heap->full_pools[i] =
-      heap->unswept_avail_pools[i] = heap->unswept_full_pools[i] = 0;
+  heap = caml_stat_alloc_noexc(sizeof(struct caml_heap_state));
+  if(heap != NULL) {
+    heap->free_pools = 0;
+    heap->num_free_pools = 0;
+    for (i = 0; i<NUM_SIZECLASSES; i++) {
+      heap->avail_pools[i] = heap->full_pools[i] =
+        heap->unswept_avail_pools[i] = heap->unswept_full_pools[i] = 0;
+    }
+    heap->next_to_sweep = 0;
+    heap->swept_large = 0;
+    heap->unswept_large = 0;
+    heap->owner = caml_domain_self();
+    memset(&heap->stats, 0, sizeof(heap->stats));
   }
-  heap->next_to_sweep = 0;
-  heap->swept_large = 0;
-  heap->unswept_large = 0;
-  heap->owner = caml_domain_self();
-  memset(&heap->stats, 0, sizeof(heap->stats));
   return heap;
 }
 

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -39,8 +39,9 @@ value caml_ephe_none = (value)&caml_dummy[1];
 struct caml_ephe_info* caml_alloc_ephe_info ()
 {
   struct caml_ephe_info* e =
-    caml_stat_alloc (sizeof(struct caml_ephe_info));
-  memset (e, 0, sizeof(struct caml_ephe_info));
+    caml_stat_alloc_noexc (sizeof(struct caml_ephe_info));
+  if(e != NULL)
+    memset (e, 0, sizeof(struct caml_ephe_info));
   return e;
 }
 


### PR DESCRIPTION
Fixes for issue #129
Modified the calls in create_domain to use non-raising variants (caml_stat_alloc_noexc instead of caml_stat_alloc), and added some cleanup error handling in the case of failure. 

