### PR TITLE
cache local roots pointer to avoid needing to look it up each time

### DIFF
--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -286,7 +286,8 @@ struct caml__roots_block {
 */
 
 #define CAMLparam0() \
-  struct caml__roots_block *caml__frame = CAML_LOCAL_ROOTS
+  struct caml__roots_block** caml_local_roots_ptr = &CAML_LOCAL_ROOTS;\
+  struct caml__roots_block *caml__frame = *caml_local_roots_ptr;\
 
 #define CAMLparam1(x) \
   CAMLparam0 (); \
@@ -314,10 +315,9 @@ struct caml__roots_block {
 
 #define CAMLxparam1(x) \
   struct caml__roots_block caml__roots_##x; \
-  caml_domain_state* domain_state_##x = Caml_state; \
   CAMLunused int caml__dummy_##x = ( \
-    (caml__roots_##x.next = domain_state_##x->local_roots), \
-    (domain_state_##x->local_roots = &caml__roots_##x), \
+    (caml__roots_##x.next = *caml_local_roots_ptr), \
+    (*caml_local_roots_ptr = &caml__roots_##x), \
     (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 1), \
@@ -327,10 +327,9 @@ struct caml__roots_block {
 
 #define CAMLxparam2(x, y) \
   struct caml__roots_block caml__roots_##x; \
-  caml_domain_state* domain_state_##x = Caml_state; \
   CAMLunused int caml__dummy_##x = ( \
-    (caml__roots_##x.next = domain_state_##x->local_roots), \
-    (domain_state_##x->local_roots = &caml__roots_##x), \
+    (caml__roots_##x.next = *caml_local_roots_ptr), \
+    (*caml_local_roots_ptr = &caml__roots_##x), \
     (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 2), \
@@ -341,10 +340,9 @@ struct caml__roots_block {
 
 #define CAMLxparam3(x, y, z) \
   struct caml__roots_block caml__roots_##x; \
-  caml_domain_state* domain_state_##x = Caml_state; \
   CAMLunused int caml__dummy_##x = ( \
-    (caml__roots_##x.next = domain_state_##x->local_roots), \
-    (domain_state_##x->local_roots = &caml__roots_##x), \
+    (caml__roots_##x.next = *caml_local_roots_ptr), \
+    (*caml_local_roots_ptr = &caml__roots_##x), \
     (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 3), \
@@ -356,10 +354,9 @@ struct caml__roots_block {
 
 #define CAMLxparam4(x, y, z, t) \
   struct caml__roots_block caml__roots_##x; \
-  caml_domain_state* domain_state_##x = Caml_state; \
   CAMLunused int caml__dummy_##x = ( \
-    (caml__roots_##x.next = domain_state_##x->local_roots), \
-    (domain_state_##x->local_roots = &caml__roots_##x), \
+    (caml__roots_##x.next = *caml_local_roots_ptr), \
+    (*caml_local_roots_ptr = &caml__roots_##x), \
     (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 4), \
@@ -372,10 +369,9 @@ struct caml__roots_block {
 
 #define CAMLxparam5(x, y, z, t, u) \
   struct caml__roots_block caml__roots_##x; \
-  caml_domain_state* domain_state_##x = Caml_state; \
   CAMLunused int caml__dummy_##x = ( \
-    (caml__roots_##x.next = domain_state_##x->local_roots), \
-    (domain_state_##x->local_roots = &caml__roots_##x), \
+    (caml__roots_##x.next = *caml_local_roots_ptr), \
+    (*caml_local_roots_ptr = &caml__roots_##x), \
     (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = 1), \
     (caml__roots_##x.ntables = 5), \
@@ -389,10 +385,9 @@ struct caml__roots_block {
 
 #define CAMLxparamN(x, size) \
   struct caml__roots_block caml__roots_##x; \
-  caml_domain_state* domain_state_##x = Caml_state; \
   CAMLunused int caml__dummy_##x = ( \
-    (caml__roots_##x.next = domain_state_##x->local_roots), \
-    (domain_state_##x->local_roots = &caml__roots_##x), \
+    (caml__roots_##x.next = *caml_local_roots_ptr), \
+    (*caml_local_roots_ptr = &caml__roots_##x), \
     (caml__roots_##x.mutexes = 0), \
     (caml__roots_##x.nitems = (size)), \
     (caml__roots_##x.ntables = 1), \
@@ -443,7 +438,7 @@ struct caml__roots_block {
 
 #define CAMLdrop do{              \
   CAMLcheck_mutexes;              \
-  CAML_LOCAL_ROOTS = caml__frame; \
+  *caml_local_roots_ptr = caml__frame; \
 }while (0)
 
 #define CAMLreturn0 do{ \


### PR DESCRIPTION
As it stands Caml_state points to a thread local global. Examining the hot assembly for some of the microbenchmarks it looks like this is looked up multiple times in the compiled code.

Caching a pointer to Caml_state at the start of a method eliminates these and shortens the sequence of generated instructions for the CAML* macros.

This has the most impact on the test_many_args_noalloc and test_many_args_alloc microbenchmarks which see a 10% reduction in runtime.

