### PR TITLE
Fix a bug with Lazy values in remembered set

### DIFF
--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -46,7 +46,7 @@ struct caml_custom_elt {
 struct caml_custom_table CAML_TABLE_STRUCT(struct caml_custom_elt);
 
 struct caml_minor_tables {
-  struct caml_ref_table major_ref, minor_ref;
+  struct caml_ref_table major_ref, major_ref_rewrites, minor_ref;
   struct caml_ephe_ref_table ephe_ref;
   struct caml_custom_table custom;
 };

--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -46,7 +46,7 @@ struct caml_custom_elt {
 struct caml_custom_table CAML_TABLE_STRUCT(struct caml_custom_elt);
 
 struct caml_minor_tables {
-  struct caml_ref_table major_ref, major_ref_rewrites, minor_ref;
+  struct caml_ref_table major_ref, minor_ref;
   struct caml_ephe_ref_table ephe_ref;
   struct caml_custom_table custom;
 };

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -631,6 +631,7 @@ void caml_empty_minor_heap_domain (struct domain* domain)
       }
     }
     CAMLassert (!caml_domain_alone() || rewrite_failures == 0);
+    reset_table((struct generic_table *)&major_ref_rewrites);
     caml_ev_end("minor_gc/update_minor_tables");
 
     caml_ev_begin("minor_gc/finalisers");

--- a/testsuite/tests/lazy/minor_major_force.ml
+++ b/testsuite/tests/lazy/minor_major_force.ml
@@ -8,37 +8,40 @@
 *)
 
 type test_record = {
-  mutable lzy: string Lazy.t;
+  mutable lzy_str: string Lazy.t;
+  mutable lzy_int: int Lazy.t;
 }
 
 let is_shared x = Obj.is_shared (Obj.repr x)
 
+let glbl_int = ref 0
 let glbl_string = ref "init"
+
+let get_random_int () =
+  Random.int 256
 
 let get_random_string () =
   Printf.sprintf "%f" (Random.float 1.)
 
-let get_lazy () =
-  lazy (glbl_string := get_random_string (); !glbl_string)
 
-let get_lazy_status x =
+let get_lazy_status fmt_str x =
   if Lazy.is_val x then
-    Printf.sprintf "%s" (Lazy.force x)
+    Printf.sprintf fmt_str (Lazy.force x)
   else
     "<not forced>"
 
+let get_lazy_int_status x = get_lazy_status "%d" x
+let get_lazy_string_status x = get_lazy_status "%s" x
+
 let dump_record_status x =
-  Printf.printf "x.lzy=%s [shared=%b]\n" (get_lazy_status x.lzy) (is_shared x.lzy)
+  Printf.printf "x.lzy_string=%s [shared=%b]\n" (get_lazy_string_status x.lzy_str) (is_shared x.lzy_str);
+  Printf.printf "x.lzy_int=%s [shared=%b]\n" (get_lazy_int_status x.lzy_int) (is_shared x.lzy_int)
 
-let update_record x =
-  let lzy = get_lazy () in
-  Printf.printf "updating: %b\n%!" (is_shared lzy);
-  x.lzy <- lzy;
-  dump_record_status x
-
-let force_lazy_val x =
-  let v = Lazy.force x.lzy in
-  Printf.printf "forcing x.lzy [%s] %b %d\n%!" v (is_shared x.lzy) (Obj.tag (Obj.repr x.lzy))
+let force_lazy_vals x =
+  let v = Lazy.force x.lzy_str in
+  Printf.printf "forcing x.lzy_str [%s] %b %d\n%!" v (is_shared x.lzy_str) (Obj.tag (Obj.repr x.lzy_str));
+  let v = Lazy.force x.lzy_int in
+  Printf.printf "forcing x.lzy_int [%d] %b %d\n%!" v (is_shared x.lzy_int) (Obj.tag (Obj.repr x.lzy_int))
 
 let do_minor_gc () =
   Printf.printf "Gc.minor ()\n%!";
@@ -46,16 +49,22 @@ let do_minor_gc () =
 
 let () =
   Random.init 34;
-  let lzy1 = get_lazy () in
-  let x = {lzy=lzy1} in
+  let x = {
+    lzy_str = lazy (glbl_string := get_random_string (); !glbl_string);
+    lzy_int = lazy (glbl_int := get_random_int (); !glbl_int);
+  } in
 
   do_minor_gc ();
   (* x should now be on the heap *)
   dump_record_status x;
   Printf.printf "x is setup on major heap\n\n%!";
 
-  update_record x;
-  force_lazy_val x;
+  Printf.printf "updating fields in x\n\n%!";
+  x.lzy_str <- lazy (glbl_string := get_random_string (); !glbl_string);
+  x.lzy_int <- lazy (glbl_int := get_random_int (); !glbl_int);
+  dump_record_status x;
+
+  force_lazy_vals x;
   dump_record_status x;
   do_minor_gc ();
   dump_record_status x

--- a/testsuite/tests/lazy/minor_major_force.ml
+++ b/testsuite/tests/lazy/minor_major_force.ml
@@ -1,0 +1,61 @@
+
+(*
+  - create a record with a mutable field that has a lazy value in it
+  - force a minor_gc to make sure that record is on the heap
+  - update the lazy value to be a minor heap value
+  - force the lazy value to be a forward to an item in the minor heap
+  - call minor_gc and watch it fail the assert which makes sure that all remembered set items have been forwarded
+*)
+
+type test_record = {
+  mutable lzy: string Lazy.t;
+}
+
+let is_shared x = Obj.is_shared (Obj.repr x)
+
+let glbl_string = ref "init"
+
+let get_random_string () =
+  Printf.sprintf "%f" (Random.float 1.)
+
+let get_lazy () =
+  lazy (glbl_string := get_random_string (); !glbl_string)
+
+let get_lazy_status x =
+  if Lazy.is_val x then
+    Printf.sprintf "%s" (Lazy.force x)
+  else
+    "<not forced>"
+
+let dump_record_status x =
+  Printf.printf "x.lzy=%s [shared=%b]\n" (get_lazy_status x.lzy) (is_shared x.lzy)
+
+let update_record x =
+  let lzy = get_lazy () in
+  Printf.printf "updating: %b\n%!" (is_shared lzy);
+  x.lzy <- lzy;
+  dump_record_status x
+
+let force_lazy_val x =
+  let v = Lazy.force x.lzy in
+  Printf.printf "forcing x.lzy [%s] %b %d\n%!" v (is_shared x.lzy) (Obj.tag (Obj.repr x.lzy))
+
+let do_minor_gc () =
+  Printf.printf "Gc.minor ()\n%!";
+  Gc.minor ()
+
+let () =
+  Random.init 34;
+  let lzy1 = get_lazy () in
+  let x = {lzy=lzy1} in
+
+  do_minor_gc ();
+  (* x should now be on the heap *)
+  dump_record_status x;
+  Printf.printf "x is setup on major heap\n\n%!";
+
+  update_record x;
+  force_lazy_val x;
+  dump_record_status x;
+  do_minor_gc ();
+  dump_record_status x

--- a/testsuite/tests/lazy/minor_major_force.reference
+++ b/testsuite/tests/lazy/minor_major_force.reference
@@ -1,0 +1,10 @@
+Gc.minor ()
+x.lzy=<not forced> [shared=true]
+x is setup on major heap
+
+updating: false
+x.lzy=<not forced> [shared=false]
+forcing x.lzy [0.152944] false 250
+x.lzy=0.152944 [shared=false]
+Gc.minor ()
+x.lzy=0.152944 [shared=true]

--- a/testsuite/tests/lazy/minor_major_force.reference
+++ b/testsuite/tests/lazy/minor_major_force.reference
@@ -1,10 +1,16 @@
 Gc.minor ()
-x.lzy=<not forced> [shared=true]
+x.lzy_string=<not forced> [shared=true]
+x.lzy_int=<not forced> [shared=true]
 x is setup on major heap
 
-updating: false
-x.lzy=<not forced> [shared=false]
-forcing x.lzy [0.152944] false 250
-x.lzy=0.152944 [shared=false]
+updating fields in x
+
+x.lzy_string=<not forced> [shared=false]
+x.lzy_int=<not forced> [shared=false]
+forcing x.lzy_str [0.152944] false 250
+forcing x.lzy_int [175] false 250
+x.lzy_string=0.152944 [shared=false]
+x.lzy_int=175 [shared=false]
 Gc.minor ()
-x.lzy=0.152944 [shared=true]
+x.lzy_string=0.152944 [shared=true]
+x.lzy_int=175 [shared=true]


### PR DESCRIPTION
This PR fixes a problem found with how the minor GC handles Lazy blocks that have been forced to `Forward_tag` and are in the remembered set. 

There is a testcase that demonstrates the issue in `testsuite/tests/lazy/minor_major_force.ml`. This sets up a record on the major heap with a mutable lazy field. It then forces this lazy value to forward to a value on the minor heap. When the minor GC code comes to atomically update the reference set pointers, the existing implementation will insert a pointer to the minor heap rather than the value on the major heap. 

This PR fixes this bug by adding a list `major_ref_rewrites` which contains the correct pointers to the heap as determined by `oldify_one`. It then applies these values atomically in the `minor_gc/update_minor_tables` stage of the minor GC.