### PR TITLE
Fix for a few space leaks

### DIFF
--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -57,6 +57,7 @@ struct heap_stats {
   intnat large_blocks;
 };
 void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
+void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* s);
 
 struct gc_stats {
   uint64_t minor_words;

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -39,6 +39,7 @@ void caml_finish_major_cycle(void);
 
 /* Ephemerons and finalisers */
 void caml_ephe_todo_list_emptied(void);
+void caml_orphan_allocated_words();
 void caml_add_orphaned_ephe(value todo_head, value todo_tail,
                             value live_head, value live_tail);
 void caml_add_orphaned_finalisers (struct caml_final_info*);

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -212,6 +212,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     domain_state->id = d->id;
     domain_state->unique_id = d->interruptor.unique_id;
     d->state.state = domain_state;
+    domain_state->critical_section_nesting = 0;
 
     if (caml_init_signal_stack() < 0) {
       goto init_signal_stack_failure;
@@ -880,6 +881,7 @@ static void domain_terminate()
   caml_ev_pause(EV_PAUSE_YIELD);
   s->terminating = 1;
   while (!finished) {
+    caml_orphan_allocated_words();
     caml_finish_sweeping();
     caml_empty_minor_heap();
     caml_finish_marking();
@@ -914,12 +916,17 @@ static void domain_terminate()
 
   caml_delete_root(domain_state->read_fault_ret_val);
   caml_stat_free(domain_state->final_info);
+  caml_stat_free(domain_state->ephe_info);
   caml_teardown_major_gc();
   caml_teardown_shared_heap(domain_state->shared_heap);
   domain_state->shared_heap = 0;
   caml_free_minor_tables(domain_state->minor_tables);
   domain_state->minor_tables = 0;
   caml_free_signal_stack();
+  
+  if(domain_state->current_stack != NULL) {
+    caml_free_stack(domain_state->current_stack);
+  }
 
   if (Caml_state->critical_section_nesting) {
     Caml_state->critical_section_nesting = 0;

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -748,6 +748,17 @@ void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
   acc->large_blocks += h->large_blocks;
 }
 
+void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
+{
+  acc->pool_words -= h->pool_words;
+  acc->pool_live_words -= h->pool_live_words;
+  acc->pool_live_blocks -= h->pool_live_blocks;
+  acc->pool_frag_words -= h->pool_frag_words;
+  acc->large_words -= h->large_words;
+  acc->large_blocks -= h->large_blocks;
+}
+
+
 void caml_sample_gc_stats(struct gc_stats* buf)
 {
   memset(buf, 0, sizeof(*buf));

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -260,8 +260,17 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
      our luck sweeping them later on */
   if( !r ) {
     int moved_pools = move_all_pools(&pool_freelist.global_full_pools[sz], &local->full_pools[sz], local->owner);
-    local->stats.pool_words += POOL_WSIZE*moved_pools;
-    pool_freelist.stats.pool_words -= POOL_WSIZE*moved_pools;
+
+    t = POOL_WSIZE*moved_pools;
+
+    local->stats.pool_words += t;
+    pool_freelist.stats.pool_words -= t;
+
+    local->stats.pool_live_words += t;
+    pool_freelist.stats.pool_live_words -= t;
+
+    local->stats.pool_live_blocks += t / sz;
+    pool_freelist.stats.pool_live_blocks -= t / sz;
   }
 
   caml_plat_unlock(&pool_freelist.lock);

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -209,7 +209,7 @@ static void calc_pool_stats(pool* a, sizeclass sz, struct heap_stats* s) {
 
     p += wh;
   }
-  CAMLassert(end - p == wastage_sizeclass[sz]);
+  Assert(end - p == wastage_sizeclass[sz]);
   s->pool_frag_words += end - p;
   s->pool_words += POOL_WSIZE;
 }
@@ -246,7 +246,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
       value* next_obj = r->next_obj;
       while( next_obj ) {
         free_objs++;
-        CAMLassert(next_obj[0] == 0);
+        Assert(next_obj[0] == 0);
         next_obj = (value*)next_obj[1];
       }
 
@@ -661,7 +661,7 @@ struct mem_stats {
 static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
   value* v;
   for (v = a->next_obj; v; v = (value*)v[1]) {
-    CAMLassert(*v == 0);
+    Assert(*v == 0);
   }
 
   value* p = (value*)((char*)a + POOL_HEADER_SZ);
@@ -671,7 +671,7 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
 
   while (p + wh <= end) {
     header_t hd = (header_t)*p;
-    CAMLassert(hd == 0 || !Has_status_hd(hd, global.GARBAGE));
+    Assert(hd == 0 || !Has_status_hd(hd, global.GARBAGE));
     if (hd) {
       s->live += Whsize_hd(hd);
       s->overhead += wh - Whsize_hd(hd);
@@ -681,7 +681,7 @@ static void verify_pool(pool* a, sizeclass sz, struct mem_stats* s) {
     }
     p += wh;
   }
-  CAMLassert(end - p == wastage_sizeclass[sz]);
+  Assert(end - p == wastage_sizeclass[sz]);
   s->overhead += end - p;
   s->alloced += POOL_WSIZE;
 }
@@ -747,14 +747,14 @@ void caml_cycle_heap(struct caml_heap_state* local) {
 
   caml_gc_log("Cycling heap [%02d]", local->owner->state->id);
   for (i = 0; i < NUM_SIZECLASSES; i++) {
-    CAMLassert(local->unswept_avail_pools[i] == 0);
+    Assert(local->unswept_avail_pools[i] == 0);
     local->unswept_avail_pools[i] = local->avail_pools[i];
     local->avail_pools[i] = 0;
-    CAMLassert(local->unswept_full_pools[i] == 0);
+    Assert(local->unswept_full_pools[i] == 0);
     local->unswept_full_pools[i] = local->full_pools[i];
     local->full_pools[i] = 0;
   }
-  CAMLassert(local->unswept_large == 0);
+  Assert(local->unswept_large == 0);
   local->unswept_large = local->swept_large;
   local->swept_large = 0;
 

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -242,6 +242,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
       r->next = 0;
       local->avail_pools[sz] = r;
 
+      #ifdef DEBUG
       int free_objs = 0;
       value* next_obj = r->next_obj;
       while( next_obj ) {
@@ -249,6 +250,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
         Assert(next_obj[0] == 0);
         next_obj = (value*)next_obj[1];
       }
+      #endif
 
       struct heap_stats tmp_stats = { 0 };
 


### PR DESCRIPTION
This PR fixes a couple of space leaks that were exposed by some domain spawning/terminating stress tests.

The first set are per-domain structures that failed to be cleaned up on termination - these are all in `domain.c`.

The second issue is in `pool_find` in `shared_heap.c` which does not currently check the global pools when looking for a new pool. In discussions with @stedolan this seems to have been a bug rather than a deliberate design choice. This PR fixes that by searching for pools in the global list that have some space or could be swept to clear some up.

The third issue that gets fixed is a GC pacing one. Right now if domains are very short lived (as they are in this stress test), we don't factor in allocations they did during their brief existence and this means we don't sweep as much as we should so we end up allocating new pools rather than using full ones that might be freed up.