### PR TITLE
move from a global pools_to_rescan to a domain-local one

### DIFF
--- a/byterun/caml/domain_state.tbl
+++ b/byterun/caml/domain_state.tbl
@@ -80,6 +80,10 @@ DOMAIN_STATE(int, id)
 
 DOMAIN_STATE(int, unique_id)
 
+DOMAIN_STATE(struct pool**, pools_to_rescan)
+DOMAIN_STATE(int, pools_to_rescan_len)
+DOMAIN_STATE(int, pools_to_rescan_count)
+
 /*****************************************************************************/
 /* GC stats (see gc_ctrl.c and the Gc module) */
 /*****************************************************************************/

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -201,7 +201,6 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     caml_plat_unlock(&s->lock);
   }
   if (d) {
-
     d->state.internals = d;
     domain_self = d;
     SET_Caml_state((void*)(d->tls_area));

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1378,6 +1378,10 @@ int caml_init_major_gc(caml_domain_state* d) {
   }
   atomic_fetch_add(&num_domains_to_final_update_first, 1);
   atomic_fetch_add(&num_domains_to_final_update_last, 1);
+
+  Caml_state->pools_to_rescan_len = 0;
+  Caml_state->pools_to_rescan_count = 0;
+  
   return 0;
 }
 
@@ -1385,7 +1389,7 @@ void caml_teardown_major_gc() {
   CAMLassert(Caml_state->mark_stack->count == 0);
   caml_stat_free(Caml_state->mark_stack->stack);
   caml_stat_free(Caml_state->mark_stack);
-  caml_stat_free(Caml_state->pools_to_rescan);
+  if( Caml_state->pools_to_rescan_len > 0 ) caml_stat_free(Caml_state->pools_to_rescan);
   Caml_state->mark_stack = NULL;
 }
 

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1388,9 +1388,15 @@ int caml_init_major_gc(caml_domain_state* d) {
 }
 
 void caml_teardown_major_gc() {
+  int c;
   CAMLassert(Caml_state->mark_stack->count == 0);
   caml_stat_free(Caml_state->mark_stack->stack);
   caml_stat_free(Caml_state->mark_stack);
+  // Rescan pools in pools_to_rescan before we free them. This is 
+  // required for correctness or objects in those pools may not be marked
+  for( c = 0 ; c < Caml_state->pools_to_rescan_count ; c++ ) {
+    caml_redarken_pool(Caml_state->pools_to_rescan[c], &mark_stack_push_act, 0);
+  }
   if( Caml_state->pools_to_rescan_len > 0 ) caml_stat_free(Caml_state->pools_to_rescan);
   Caml_state->mark_stack = NULL;
 }

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1388,15 +1388,9 @@ int caml_init_major_gc(caml_domain_state* d) {
 }
 
 void caml_teardown_major_gc() {
-  int c;
   CAMLassert(Caml_state->mark_stack->count == 0);
   caml_stat_free(Caml_state->mark_stack->stack);
   caml_stat_free(Caml_state->mark_stack);
-  // Rescan pools in pools_to_rescan before we free them. This is 
-  // required for correctness or objects in those pools may not be marked
-  for( c = 0 ; c < Caml_state->pools_to_rescan_count ; c++ ) {
-    caml_redarken_pool(Caml_state->pools_to_rescan[c], &mark_stack_push_act, 0);
-  }
   if( Caml_state->pools_to_rescan_len > 0 ) caml_stat_free(Caml_state->pools_to_rescan);
   Caml_state->mark_stack = NULL;
 }

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -42,6 +42,7 @@
   leaving it small for now means the overflow code gets more testing.
 */
 #define MARK_STACK_SIZE (1 << 14)
+#define INITIAL_POOLS_TO_RESCAN_LEN 4
 
 typedef struct {
   value block;
@@ -1379,9 +1380,10 @@ int caml_init_major_gc(caml_domain_state* d) {
   atomic_fetch_add(&num_domains_to_final_update_first, 1);
   atomic_fetch_add(&num_domains_to_final_update_last, 1);
 
-  Caml_state->pools_to_rescan_len = 0;
+  Caml_state->pools_to_rescan = caml_stat_alloc_noexc(INITIAL_POOLS_TO_RESCAN_LEN * sizeof(struct pool*));
+  Caml_state->pools_to_rescan_len = INITIAL_POOLS_TO_RESCAN_LEN;
   Caml_state->pools_to_rescan_count = 0;
-  
+
   return 0;
 }
 


### PR DESCRIPTION
The motivation behind this PR comes from experiencing a segfault during stress testing that was traced back to a pool being rescanned while another domain was allocating in to it. To address this the pools to rescan are now moved to a domain local list which ensures this case is no longer possible.