### PR TITLE
Fixes backtrace for noalloc C-calls

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -66,8 +66,12 @@ let cfi_remember_state () =
 let cfi_restore_state () =
   if Config.asm_cfi_supported then D.cfi_restore_state ()
 
+let cfi_def_cfa reg =
+  if Config.asm_cfi_supported then D.cfi_def_cfa reg
+
 let cfi_def_cfa_offset n =
   if Config.asm_cfi_supported then D.cfi_def_cfa_offset n
+
 
 let emit_debug_info dbg =
   emit_debug_info_gen dbg D.file D.loc
@@ -613,18 +617,14 @@ let emit_instr fallthrough i =
         if Config.stats then begin
           I.inc (domain_field Domainstate.Domain_extcall_noalloc);
         end;
-        cfi_remember_state ();
         I.mov (domain_field Domainstate.Domain_c_stack) rsp;
-        (* FIXME: CFI *)
-        (* cfi_def_cfa_offset 8; *)
+        cfi_def_cfa "rsp";
+        I.sub (int 16) rsp;
+        cfi_def_cfa_offset 16;
         emit_call func;
-        (* FIXME KC:
-        if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
-        end
-        *)
+        I.add (int 16) rsp;
+        cfi_def_cfa_offset 16;
         I.mov rbp rsp;
-        cfi_restore_state ();
       end
   | Lop(Istackoffset n) ->
       if n < 0

--- a/asmcomp/x86_ast.mli
+++ b/asmcomp/x86_ast.mli
@@ -210,6 +210,7 @@ type asm_line =
   | Cfi_startproc
   | Cfi_remember_state
   | Cfi_restore_state
+  | Cfi_def_cfa of string
   | Cfi_def_cfa_offset of int
   | File of int * string (* (file_num, file_name) *)
   | Indirect_symbol of string

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -88,6 +88,7 @@ module D = struct
   let cfi_startproc () = directive Cfi_startproc
   let cfi_remember_state () = directive Cfi_remember_state
   let cfi_restore_state () = directive Cfi_restore_state
+  let cfi_def_cfa reg = directive (Cfi_def_cfa reg)
   let cfi_def_cfa_offset n = directive (Cfi_def_cfa_offset n)
   let comment s = directive (Comment s)
   let data () = section [ ".data" ] None []

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -78,6 +78,7 @@ module D : sig
   val cfi_startproc: unit -> unit
   val cfi_remember_state: unit -> unit
   val cfi_restore_state: unit -> unit
+  val cfi_def_cfa : string -> unit
   val cfi_def_cfa_offset: int -> unit
   val comment: string -> unit
   val data: unit -> unit

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -281,6 +281,7 @@ let print_line b = function
   | Cfi_startproc -> bprintf b "\t.cfi_startproc"
   | Cfi_remember_state -> bprintf b "\t.cfi_remember_state"
   | Cfi_restore_state -> bprintf b "\t.cfi_restore_state"
+  | Cfi_def_cfa reg -> bprintf b "\t.cfi_def_cfa %%%s, 0" reg
   | Cfi_def_cfa_offset n -> bprintf b "\t.cfi_def_cfa_offset %d" n
   | File (file_num, file_name) ->
       bprintf b "\t.file\t%d\t\"%s\""

--- a/asmcomp/x86_masm.ml
+++ b/asmcomp/x86_masm.ml
@@ -239,6 +239,7 @@ let print_line b = function
   | Cfi_adjust_cfa_offset _
   | Cfi_endproc
   | Cfi_startproc
+  | Cfi_def_cfa _
   | Cfi_def_cfa_offset _
   | Cfi_remember_state
   | Cfi_restore_state


### PR DESCRIPTION
This patch adds necessary DWARF information to ensure that the
backtrace works for external C class that do not allocate.