### PR TITLE
Fix DWARF CFI for non-allocating external calls

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -615,14 +615,16 @@ let emit_instr fallthrough i =
         end;
         cfi_remember_state ();
         I.mov (domain_field Domainstate.Domain_c_stack) rsp;
-        (* FIXME: CFI *)
-        (* cfi_def_cfa_offset 8; *)
+        cfi_def_cfa_offset 0;
+
+        (* Keep GDB happy. If the cfa_offset was left at 0, then GDB complains
+         * that the frame did not save the PC and truncates the backtrace.
+         * Subtract rsp by 16 (instead of 8) to keep the stack aligned to
+         * 16-byte boundary. *)
+        I.sub (int 16) rsp;
+        cfi_adjust_cfa_offset 16;
+
         emit_call func;
-        (* FIXME KC:
-        if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
-        end
-        *)
         I.mov rbp rsp;
         cfi_restore_state ();
       end
@@ -970,14 +972,14 @@ let emit_profile () =
     I.mov rsp r10;
     cfi_remember_state ();
     I.mov (domain_field Domainstate.Domain_c_stack) rsp;
-    cfi_def_cfa_offset 8;
-    I.push r10;
-    cfi_adjust_cfa_offset 8;
+    cfi_def_cfa_offset 0;
+    I.sub (int 16) rsp;
+    cfi_adjust_cfa_offset 16;
+    I.mov r10 (mem64 NONE 0 RSP);
     (* No Spacetime instrumentation needed: [mcount] cannot call anything
        OCaml-related. *)
     emit_call "mcount";
-    I.pop r10;
-    cfi_adjust_cfa_offset (-8);
+    I.mov (mem64 NONE 0 RSP) r10;
     I.mov r10 rsp;
     cfi_restore_state()
   end


### PR DESCRIPTION
Fixes the DWARF CFI for non-allocating external calls. Consider this program:

```ocaml
let foo () =
  classify_float 1.0;
  print_string "Hello, world!"

let _ = foo ()
```

In master, backtrace at the entry to `caml_classify_float_unboxed` used to produce a corrupted backtrace:

![image](https://user-images.githubusercontent.com/410484/72279640-90a75d00-365c-11ea-9037-63d6ca7b4227.png)

Now it produces the correct backtrace:
 
![image](https://user-images.githubusercontent.com/410484/72279469-34dcd400-365c-11ea-9e4f-873e18501e18.png)

The position of frames `#1` and `#2` are swapped; Ideally, `<signal handler called>` should come before `camlTest__foo_1002`, to indicate the boundary between OCaml and C. But this is not important for correctness and will not be fixed. 

I have fixed the implementation in the `emit_profile` function as well, although `emit_profile` is not safe to be called in multicore since we may stack overflow in OCaml calling `mcount` directly. But that's a separate problem. 