### PR TITLE
Give more space for mark stack.

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -36,12 +36,7 @@
 #include "caml/startup_aux.h"
 #include "caml/weak.h"
 
-/*
-  FIXME: This is far too small. A better policy would be to match
-  OCaml's: allow the mark stack to grow to major_heap / 32. However,
-  leaving it small for now means the overflow code gets more testing.
-*/
-#define MARK_STACK_SIZE (1 << 14)
+#define MARK_STACK_INIT_SIZE (1 << 10)
 #define INITIAL_POOLS_TO_RESCAN_LEN 4
 
 typedef struct {
@@ -53,6 +48,7 @@ typedef struct {
 struct mark_stack {
   mark_entry* stack;
   uintnat count;
+  uintnat size;
 };
 
 uintnat caml_percent_free = Percent_free_def;
@@ -466,6 +462,32 @@ static struct pool* find_pool_to_rescan();
 #define Is_markable(v) (Is_block(v) && !Is_minor(v))
 #endif
 
+static void realloc_mark_stack (struct mark_stack* stk)
+{
+  mark_entry* new;
+  uintnat mark_stack_bsize = stk->size * sizeof(mark_entry);
+
+  if ( mark_stack_bsize < caml_heap_size(Caml_state->shared_heap) / 32) {
+    caml_gc_log ("Growing mark stack to %"ARCH_INTNAT_PRINTF_FORMAT"uk bytes\n",
+                 (intnat) mark_stack_bsize * 2 / 1024);
+
+    new = (mark_entry*) caml_stat_resize_noexc ((char*) stk->stack,
+                                                2 * mark_stack_bsize);
+    if (new != NULL) {
+      stk->stack = new;
+      stk->size *= 2;
+      return;
+    }
+    caml_gc_log ("No room for growing mark stack. Pruning..\n");
+  }
+  caml_gc_log ("Mark stack size is %"ARCH_INTNAT_PRINTF_FORMAT"u"
+               "bytes (> 32 * major heap size of this domain %"
+               ARCH_INTNAT_PRINTF_FORMAT"u bytes. Pruning..\n",
+               mark_stack_bsize,
+               caml_heap_size(Caml_state->shared_heap));
+  mark_stack_prune(stk);
+}
+
 static void mark_stack_push(struct mark_stack* stk, mark_entry e)
 {
   value v;
@@ -485,8 +507,9 @@ static void mark_stack_push(struct mark_stack* stk, mark_entry e)
       /* keep going */
       e.offset++;
   }
-  if (stk->count >= MARK_STACK_SIZE)
-    mark_stack_prune(stk);
+  if (stk->count == stk->size)
+    realloc_mark_stack(stk);
+
   stk->stack[stk->count++] = e;
 }
 
@@ -1375,13 +1398,15 @@ int caml_init_major_gc(caml_domain_state* d) {
   if(Caml_state->mark_stack == NULL) {
     return -1;
   }
-  Caml_state->mark_stack->stack = caml_stat_alloc_noexc(MARK_STACK_SIZE * sizeof(mark_entry));
+  Caml_state->mark_stack->stack =
+    caml_stat_alloc_noexc(MARK_STACK_INIT_SIZE * sizeof(mark_entry));
   if(Caml_state->mark_stack->stack == NULL) {
     caml_stat_free(Caml_state->mark_stack);
     Caml_state->mark_stack = NULL;
     return -1;
   }
   Caml_state->mark_stack->count = 0;
+  Caml_state->mark_stack->size = MARK_STACK_INIT_SIZE;
   /* Fresh domains do not need to performing marking or sweeping. */
   d->sweeping_done = 1;
   d->marking_done = 1;

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -246,11 +246,11 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
       caml_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
 
       if (local->stats.pool_words > local->stats.pool_max_words)
-        local->stats.pool_max_words = local->stats.pool_words;    
+        local->stats.pool_max_words = local->stats.pool_words;
     }
   }
 
-  /* There were no global avail pools, so let's adopt the full ones and try 
+  /* There were no global avail pools, so let's adopt the full ones and try
      our luck sweeping them later on */
   if( !r ) {
     struct heap_stats tmp_stats = { 0 };
@@ -265,13 +265,13 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
     int moved_pools = move_all_pools(&pool_freelist.global_full_pools[sz], &local->full_pools[sz], local->owner);
 
     if (local->stats.pool_words > local->stats.pool_max_words)
-      local->stats.pool_max_words = local->stats.pool_words;    
+      local->stats.pool_max_words = local->stats.pool_words;
   }
 
   caml_plat_unlock(&pool_freelist.lock);
 
   if( !r ) {
-    pool_sweep(local, &local->full_pools[sz], sz);    
+    pool_sweep(local, &local->full_pools[sz], sz);
     r = local->avail_pools[sz];
   }
 


### PR DESCRIPTION
Allow mark stack to be small initially and then grow until it is 1/32 of
the size of the shared heap on a domain. At that point, prune the mark
stack to limit the size of the growth.