### PR TITLE
Revert "Let only one domain scan the globals"

### DIFF
--- a/byterun/globroots.c
+++ b/byterun/globroots.c
@@ -46,7 +46,6 @@
 
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 static value roots_all = Val_unit;
-atomic_uintnat caml_globals_scanned = 0;
 
 CAMLexport caml_root caml_create_root(value init)
 {
@@ -211,17 +210,10 @@ static void scan_native_globals(scanning_action f, void* fdata)
 #endif
 
 void caml_scan_global_roots(scanning_action f, void* fdata) {
-  uintnat v = 0;
-  if(atomic_compare_exchange_strong(&caml_globals_scanned, &v, 1)) {
-    scan_global_roots(f, fdata);
+  /* FIXME KC: Needs to be done only once per major cycle. Currently, every
+   * domain scans global roots */
+  scan_global_roots(f, fdata);
 #ifdef NATIVE_CODE
-    scan_native_globals(f, fdata);
+  scan_native_globals(f, fdata);
 #endif
-    /* If we are running verification code, then we will need to scan the roots
-     * again for marking. */
-    if (f == &caml_verify_root)
-      atomic_store(&caml_globals_scanned, 0);
-  } else {
-    CAMLassert (v == 1);
-  }
 }

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -68,7 +68,6 @@ static atomic_uintnat num_domains_to_final_update_first;
 static atomic_uintnat num_domains_to_final_update_last;
 
 static atomic_uintnat terminated_domains_allocated_words;
-extern atomic_uintnat caml_globals_scanned;
 
 gc_phase_t caml_gc_phase;
 
@@ -883,13 +882,12 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused)
       atomic_store_rel(&num_domains_to_mark, num_domains_in_stw);
 
       caml_gc_phase = Phase_sweep_and_mark_main;
-      atomic_store_rel(&ephe_cycle_info.num_domains_todo, num_domains_in_stw);
-      atomic_store_rel(&ephe_cycle_info.ephe_cycle, 0);
-      atomic_store_rel(&ephe_cycle_info.num_domains_done, 0);
+      atomic_store(&ephe_cycle_info.num_domains_todo, num_domains_in_stw);
+      atomic_store(&ephe_cycle_info.ephe_cycle, 0);
+      atomic_store(&ephe_cycle_info.num_domains_done, 0);
       atomic_store_rel(&num_domains_to_ephe_sweep, num_domains_in_stw);
       atomic_store_rel(&num_domains_to_final_update_first, num_domains_in_stw);
       atomic_store_rel(&num_domains_to_final_update_last, num_domains_in_stw);
-      atomic_store_rel(&caml_globals_scanned, 0);
     }
     // should interrupts be processed here or not?
     // depends on whether marking above may need interrupts

--- a/byterun/obj.c
+++ b/byterun/obj.c
@@ -61,7 +61,7 @@ CAMLprim value caml_obj_forward_lazy (value blk, value fwd)
 
   /* Modify field before setting tag */
   caml_modify_field(blk, 0, fwd);
-again:
+  again:
   hd = Hd_val(blk);
 
   /* This function is only called on Lazy_tag objects. The only racy write to

--- a/byterun/roots.c
+++ b/byterun/roots.c
@@ -40,6 +40,7 @@
 */
 
 intnat caml_globals_inited = 0;
+static intnat caml_globals_scanned = 0;
 #endif
 
 CAMLexport void (*caml_scan_roots_hook)(scanning_action, void* fdata, struct domain*) = NULL;


### PR DESCRIPTION
Reverts ocaml-multicore/ocaml-multicore#276. The global roots are plain old-linked lists, which are already incrementally scanned. Even if multiple domains race to scan it, the head of the list will be added to every domain, one of the domain will win the race to mark the first object. Other domains will not do any more work. 