### PR TITLE
Fix assert in caml_ephe_clean

### DIFF
--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -161,7 +161,7 @@ void caml_ephe_clean (struct domain* d, value v) {
     if (release_data) {
       Op_val(v)[CAML_EPHE_DATA_OFFSET] = caml_ephe_none;
     } else {
-      CAMLassert (!Is_block(child) && !is_unmarked(child));
+      CAMLassert (!Is_block(child) || !is_unmarked(child));
     }
   }
 }


### PR DESCRIPTION
This PR fixes an assert in caml_ephe_clean where we check that blocks not released are marked. We saw this fail on some multicore machines in `ephetest_par` with the stop-the-world minor gc branch. 