### PR TITLE
Fix for mark stack being too small

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -36,7 +36,9 @@
 #include "caml/startup_aux.h"
 #include "caml/weak.h"
 
-#define MARK_STACK_INIT_SIZE (1 << 10)
+/* NB the MARK_STACK_INIT_SIZE must be larger than the number of objects
+   that can be in a pool, see POOL_WSIZE */
+#define MARK_STACK_INIT_SIZE (1 << 12)
 #define INITIAL_POOLS_TO_RESCAN_LEN 4
 
 typedef struct {


### PR DESCRIPTION
This PR bumps up MARK_STACK_INIT_SIZE which must be larger than POOL_WSIZE. If this isn't done, it is possible for a domain to get into a loop where it tries to realloc and prune the mark stack, but will never have a mark stack size big enough to mark a pool. 