### PR TITLE
Introduce an 'opportunistic' major collection slice fn

### DIFF
--- a/byterun/caml/domain_state.tbl
+++ b/byterun/caml/domain_state.tbl
@@ -42,6 +42,8 @@ DOMAIN_STATE(uintnat, allocated_words)
 
 DOMAIN_STATE(uintnat, swept_words)
 
+DOMAIN_STATE(uintnat, opportunistic_work)
+
 DOMAIN_STATE(struct caml__roots_block*, local_roots)
 
 DOMAIN_STATE(struct caml_ephe_info*, ephe_info)

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -25,6 +25,7 @@ typedef enum {
 } gc_phase_t;
 extern gc_phase_t caml_gc_phase;
 
+intnat caml_opportunistic_major_collection_slice (intnat, intnat* left /* out */);
 intnat caml_major_collection_slice (intnat, intnat* left /* out */);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -922,7 +922,7 @@ static void domain_terminate()
   caml_free_minor_tables(domain_state->minor_tables);
   domain_state->minor_tables = 0;
   caml_free_signal_stack();
-  
+
   if(domain_state->current_stack != NULL) {
     caml_free_stack(domain_state->current_stack);
   }
@@ -1032,7 +1032,7 @@ CAMLprim value caml_ml_domain_yield(value unused)
       caml_plat_wait(&s->cond);
     } else {
       caml_plat_unlock(&s->lock);
-      caml_major_collection_slice(Chunk_size, &left);
+      caml_opportunistic_major_collection_slice(Chunk_size, &left);
       if (left == Chunk_size)
         found_work = 0;
       caml_plat_lock(&s->lock);
@@ -1109,7 +1109,7 @@ CAMLprim value caml_ml_domain_yield_until(value t)
       }
     } else {
       caml_plat_unlock(&s->lock);
-      caml_major_collection_slice(Chunk_size, &left);
+      caml_opportunistic_major_collection_slice(Chunk_size, &left);
       if (left == Chunk_size)
         found_work = 0;
       caml_plat_lock(&s->lock);

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1057,6 +1057,11 @@ static intnat major_collection_slice(intnat howmuch,
   uintnat saved_ephe_cycle;
   uintnat saved_major_cycle;
 
+  /* shortcut out if there is no opportunistic work to be done
+   * NB: needed particularly to avoid caml_ev spam when polling */
+  if (opportunistic && domain_state->sweeping_done && domain_state->marking_done)
+    return computed_work;
+
   caml_ev_begin("major_gc/slice");
 
   if (!domain_state->sweeping_done) {

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -301,7 +301,7 @@ double caml_mean_space_overhead ()
 
 static uintnat default_slice_budget() {
   double p, heap_words;
-  intnat computed_work;
+  intnat computed_work, opportunistic_credit;
   /*
      Free memory at the start of the GC cycle (garbage + free list) (assumed):
                  FM = heap_words * caml_percent_free
@@ -349,6 +349,22 @@ static uintnat default_slice_budget() {
 
   computed_work = (intnat) (p * (heap_blocks + (heap_words * 100 / (100 + caml_percent_free))));
 
+  /* adjust computed work for opportunistic_work done by this domain already */
+  if ( Caml_state->opportunistic_work > computed_work ) {
+    /* bound the credit that opportunistic_work can have vs computed_work */
+    if (Caml_state->opportunistic_work > computed_work*2) {
+     Caml_state->opportunistic_work = 2*computed_work;
+    }
+
+    opportunistic_credit = computed_work;
+    Caml_state->opportunistic_work -= computed_work;
+    computed_work = 0;
+  } else {
+    opportunistic_credit = Caml_state->opportunistic_work;
+    Caml_state->opportunistic_work = 0;
+    computed_work -= opportunistic_credit;
+  }
+
   caml_gc_message (0x40, "heap_words = %"
                          ARCH_INTNAT_PRINTF_FORMAT "u\n",
                          (uintnat)heap_words);
@@ -359,6 +375,7 @@ static uintnat default_slice_budget() {
                          ARCH_INTNAT_PRINTF_FORMAT "uu\n",
                    (uintnat) (p * 1000000));
   caml_gc_message (0x40, "ordered work = %ld words\n", (intnat)-1);
+  caml_gc_message (0x40, "opportunistic work credit = %ld words\n", opportunistic_credit);
   caml_gc_message (0x40, "computed work = %ld words\n", computed_work);
 
   return computed_work;
@@ -936,6 +953,8 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused)
   /* Mark roots for new cycle */
   domain->state->marking_done = 0;
 
+  domain->state->opportunistic_work = 0;
+
   caml_ev_begin("major_gc/roots");
   caml_do_roots (&caml_darken, NULL, domain, 0);
   caml_ev_end("major_gc/roots");
@@ -1016,12 +1035,14 @@ static void try_complete_gc_phase (struct domain* domain, void* unused)
     }
   }
   caml_global_barrier_end(b);
+  domain->state->opportunistic_work = 0;
 }
 
 #define Chunk_size 0x4000
 
 static intnat major_collection_slice(intnat howmuch,
                                      intnat from_barrier,
+                                     intnat opportunistic,
                                      intnat* budget_left /* out */)
 {
   struct domain* d = caml_domain_self();
@@ -1104,59 +1125,61 @@ mark_again:
     caml_ev_end("major_gc/mark");
   mark_work -= budget;
 
-  /* Finalisers */
-  if (caml_gc_phase == Phase_mark_final &&
-      caml_final_update_first(d)) {
-    /* This domain has updated finalise first values */
-    atomic_fetch_add_verify_ge0(&num_domains_to_final_update_first, -1);
-    if (budget > 0 && !domain_state->marking_done)
-      goto mark_again;
-  }
-
-  if (caml_gc_phase == Phase_sweep_ephe &&
-      caml_final_update_last(d)) {
-    /* This domain has updated finalise last values */
-    atomic_fetch_add_verify_ge0(&num_domains_to_final_update_last, -1);
-    /* Nothing has been marked while updating last */
-  }
-
-  caml_adopt_orphaned_work();
-
-  /* Ephemerons */
-  saved_ephe_cycle = atomic_load_acq(&ephe_cycle_info.ephe_cycle);
-  if (domain_state->ephe_info->todo != (value) NULL &&
-      saved_ephe_cycle > domain_state->ephe_info->cycle) {
-    caml_ev_begin("major_gc/ephe_mark");
-    budget = ephe_mark(budget, saved_ephe_cycle);
-    caml_ev_end("major_gc/ephe_mark");
-    if (domain_state->ephe_info->todo == (value) NULL)
-      caml_ephe_todo_list_emptied ();
-    else if (budget > 0 && domain_state->marking_done)
-      record_ephe_marking_done(saved_ephe_cycle);
-    else if (budget > 0) goto mark_again;
-  }
-
-  if (caml_gc_phase == Phase_sweep_ephe &&
-      domain_state->ephe_info->todo != 0) {
-    caml_ev_begin("major_gc/ephe_sweep");
-    budget = ephe_sweep (d, budget);
-    caml_ev_end("major_gc/ephe_sweep");
-    if (domain_state->ephe_info->todo == 0) {
-      atomic_fetch_add_verify_ge0(&num_domains_to_ephe_sweep, -1);
+  if (!opportunistic) {
+    /* Finalisers */
+    if (caml_gc_phase == Phase_mark_final &&
+        caml_final_update_first(d)) {
+      /* This domain has updated finalise first values */
+      atomic_fetch_add_verify_ge0(&num_domains_to_final_update_first, -1);
+      if (budget > 0 && !domain_state->marking_done)
+        goto mark_again;
     }
-  }
 
-  /* Complete GC phase */
-  if (is_complete_phase_sweep_and_mark_main(d) ||
-      is_complete_phase_mark_final (d)) {
-    caml_ev_begin("major_gc/phase_change");
-    if (from_barrier) {
-      try_complete_gc_phase (d, (void*)0);
-    } else {
-      caml_try_run_on_all_domains (&try_complete_gc_phase, 0);
+    if (caml_gc_phase == Phase_sweep_ephe &&
+        caml_final_update_last(d)) {
+      /* This domain has updated finalise last values */
+      atomic_fetch_add_verify_ge0(&num_domains_to_final_update_last, -1);
+      /* Nothing has been marked while updating last */
     }
-    caml_ev_end("major_gc/phase_change");
-    if (budget > 0) goto mark_again;
+
+    caml_adopt_orphaned_work();
+
+    /* Ephemerons */
+    saved_ephe_cycle = atomic_load_acq(&ephe_cycle_info.ephe_cycle);
+    if (domain_state->ephe_info->todo != (value) NULL &&
+        saved_ephe_cycle > domain_state->ephe_info->cycle) {
+      caml_ev_begin("major_gc/ephe_mark");
+      budget = ephe_mark(budget, saved_ephe_cycle);
+      caml_ev_end("major_gc/ephe_mark");
+      if (domain_state->ephe_info->todo == (value) NULL)
+        caml_ephe_todo_list_emptied ();
+      else if (budget > 0 && domain_state->marking_done)
+        record_ephe_marking_done(saved_ephe_cycle);
+      else if (budget > 0) goto mark_again;
+    }
+
+    if (caml_gc_phase == Phase_sweep_ephe &&
+        domain_state->ephe_info->todo != 0) {
+      caml_ev_begin("major_gc/ephe_sweep");
+      budget = ephe_sweep (d, budget);
+      caml_ev_end("major_gc/ephe_sweep");
+      if (domain_state->ephe_info->todo == 0) {
+        atomic_fetch_add_verify_ge0(&num_domains_to_ephe_sweep, -1);
+      }
+    }
+
+    /* Complete GC phase */
+    if (is_complete_phase_sweep_and_mark_main(d) ||
+        is_complete_phase_mark_final (d)) {
+      caml_ev_begin("major_gc/phase_change");
+      if (from_barrier) {
+        try_complete_gc_phase (d, (void*)0);
+      } else {
+        caml_try_run_on_all_domains (&try_complete_gc_phase, 0);
+      }
+      caml_ev_end("major_gc/phase_change");
+      if (budget > 0) goto mark_again;
+    }
   }
 
   caml_ev_end("major_gc/slice");
@@ -1170,8 +1193,10 @@ mark_again:
               (unsigned long)(domain_state->stat_blocks_marked - blocks_marked_before));
   domain_state->stat_major_words += domain_state->allocated_words;
   domain_state->allocated_words = 0;
+  if (opportunistic)
+  domain_state->opportunistic_work += computed_work - budget;
 
-  if (is_complete_phase_sweep_ephe(d)) {
+  if (!opportunistic && is_complete_phase_sweep_ephe(d)) {
     saved_major_cycle = caml_major_cycles_completed;
     /* To handle the case where multiple domains try to finish the major
       cycle simultaneously, we loop until the current cycle has ended,
@@ -1191,9 +1216,14 @@ mark_again:
 }
 
 
+intnat caml_opportunistic_major_collection_slice(intnat howmuch, intnat* budget_left /* out */)
+{
+  return major_collection_slice(howmuch, 0, 1, budget_left);
+}
+
 intnat caml_major_collection_slice(intnat howmuch, intnat* budget_left /* out */)
 {
-  return major_collection_slice(howmuch, 0, budget_left);
+  return major_collection_slice(howmuch, 0, 0, budget_left);
 }
 
 static void finish_major_cycle_callback (struct domain* domain, void* arg)
@@ -1202,7 +1232,7 @@ static void finish_major_cycle_callback (struct domain* domain, void* arg)
   CAMLassert (domain == caml_domain_self());
   caml_empty_minor_heap();
   while (saved_major_cycles == caml_major_cycles_completed) {
-    major_collection_slice(10000000, 1, 0);
+    major_collection_slice(10000000, 1, 0, 0);
   }
 }
 
@@ -1411,6 +1441,7 @@ int caml_init_major_gc(caml_domain_state* d) {
   d->sweeping_done = 1;
   d->marking_done = 1;
   d->stealing = 0;
+  d->opportunistic_work = 0;
   /* Finalisers. Fresh domains participate in updating finalisers. */
   d->final_info = caml_alloc_final_info ();
   if(d->final_info == NULL) {


### PR DESCRIPTION
This PR alters major collection slice to allow an 'opportunistic' collection which can be called from `caml_ml_domain_yield*`. We want to change the behaviour with the yield functions because as things stand, repeated calls to the yield function cause the GC to continually change phase and this causes interrupts on other domains. 

The opportunistic slice does not change the phase of the GC. It introduces a credit for work done that is then offset when a standard major GC slice is performed. 

This provides the basis in the future for doing opportunistic major mark and sweep work while waiting for synchronization with other domains. 