### PR TITLE
Do fflush and variable args in caml_gc_log only when enabled

### DIFF
--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -85,18 +85,15 @@ void caml_alloc_point_here()
 
 void caml_gc_log (char *msg, ...)
 {
-  va_list args;
-  va_start (args, msg);
-
-  char fmtbuf[512];
-
   if ((caml_params->verb_gc & 0x800) != 0) {
+    char fmtbuf[512];
+    va_list args;
+    va_start (args, msg);
     sprintf(fmtbuf, "[%02d] %s\n", Caml_state ? Caml_state->id : -1, msg);
     vfprintf(stderr, fmtbuf, args);
+    va_end (args);
+    fflush(stderr);
   }
-  fflush(stderr);
-
-  va_end (args);
 }
 
 void caml_gc_message (int level, char *msg, ...)


### PR DESCRIPTION
This PR cleans up `caml_gc_log` to check that `fflush` is only called when it GC logging is enabled. 
This makes the implementation match `caml_gc_message`.