### PR TITLE
Bump EVENT_BUF_SIZE in eventlog.c to 32768

### DIFF
--- a/byterun/eventlog.c
+++ b/byterun/eventlog.c
@@ -40,7 +40,7 @@ static struct evbuf_list_node evbuf_head =
 static FILE* output;
 static int64_t startup_timestamp;
 
-#define EVENT_BUF_SIZE 4096
+#define EVENT_BUF_SIZE 32768
 struct event_buffer {
   struct evbuf_list_node list;
   uintnat ev_flushed;


### PR DESCRIPTION
This PR bumps the EVENT_BUF_SIZE to reduce the number of times the buffer is flushed which can be useful when debugging with event trace data. 