### PR TITLE
write_barrier optimizations

### DIFF
--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -52,11 +52,11 @@ CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t);
 CAMLextern void caml_free_dependent_memory (mlsize_t);
-CAMLextern void caml_modify_field (value, int, value);
+CAMLextern void caml_modify_field (value, intnat, value);
 #define caml_modify_field caml_modify_field
-CAMLextern int caml_atomic_cas_field (value, int, value, value);
-CAMLextern value caml_read_barrier (value, int);
-CAMLextern void caml_initialize_field (value, int, value);
+CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
+CAMLextern value caml_read_barrier (value, intnat);
+CAMLextern void caml_initialize_field (value, intnat, value);
 #define caml_initialize_field caml_initialize_field
 CAMLextern void caml_blit_fields (value src, int srcoff, value dst, int dstoff, int n);
 CAMLextern value caml_check_urgent_gc (value);

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -217,6 +217,9 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #define Is_minor(val) \
   ((((uintnat)(val) ^ (uintnat)Caml_state) & Minor_val_bitmask) == 0)
 
+#define Is_block_and_young(val) Is_young(val)
+#define Is_block_and_minor(val) Is_minor(val)
+
 /* Is_foreign(val) is true iff val is a block in another domain's minor heap.
    Since all minor heaps lie in one aligned block, this can be tested via
    more bitmasking. */

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -435,7 +435,7 @@ static inline value Field_imm(value x, int i) {
   return v;
 }
 
-CAMLextern value caml_read_barrier(value, int);
+CAMLextern value caml_read_barrier(value, intnat);
 static inline value Field(value x, int i) {
   Assert (Hd_val(x));
   value v = (((value*)x))[i];
@@ -443,7 +443,7 @@ static inline value Field(value x, int i) {
   return Is_foreign(v) ? caml_read_barrier(x, i) : v;
 }
 
-static inline void caml_read_field(value x, int i, value* ret) {
+static inline void caml_read_field(value x, intnat i, value* ret) {
   Assert (Hd_val(x));
   /* See Note [MM] in memory.c */
   value v = atomic_load_explicit(&Op_atomic_val(x)[i], memory_order_relaxed);

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -124,11 +124,12 @@
    generated.
 */
 
-static void write_barrier(value obj, int field, value old_val, value new_val) __attribute__((always_inline));
+static void write_barrier(value obj, intnat field, value old_val, value new_val) __attribute__((always_inline));
+
 
 /* The write barrier does not read or write the heap, it just
    modifies domain-local data structures. */
-static void write_barrier(value obj, int field, value old_val, value new_val)
+static void write_barrier(value obj, intnat field, value old_val, value new_val)
 {
   caml_domain_state* domain_state = Caml_state;
 
@@ -162,7 +163,7 @@ static void write_barrier(value obj, int field, value old_val, value new_val)
   }
 }
 
-CAMLexport void caml_modify_field (value obj, int field, value val)
+CAMLexport void caml_modify_field (value obj, intnat field, value val)
 {
   Assert (Is_block(obj));
   Assert (!Is_foreign(obj));
@@ -180,7 +181,7 @@ CAMLexport void caml_modify_field (value obj, int field, value val)
                         memory_order_release);
 }
 
-CAMLexport void caml_initialize_field (value obj, int field, value val)
+CAMLexport void caml_initialize_field (value obj, intnat field, value val)
 {
   Assert(Is_block(obj));
   Assert(!Is_foreign(obj));
@@ -204,7 +205,7 @@ CAMLexport void caml_initialize_field (value obj, int field, value val)
   Op_val(obj)[field] = val;
 }
 
-CAMLexport int caml_atomic_cas_field (value obj, int field, value oldval, value newval)
+CAMLexport int caml_atomic_cas_field (value obj, intnat field, value oldval, value newval)
 {
   if (Is_young(obj) || caml_domain_alone()) {
     /* non-atomic CAS since only this thread can access the object */
@@ -455,7 +456,7 @@ static void send_read_fault(struct read_fault_req* req)
   }
 }
 
-CAMLexport value caml_read_barrier(value obj, int field)
+CAMLexport value caml_read_barrier(value obj, intnat field)
 {
   /* A GC may occur just before or just after sending a fault. The obj value
      must be root. The orig value must *not* be a root, since it may contain a

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -124,6 +124,8 @@
    generated.
 */
 
+static void write_barrier(value obj, int field, value old_val, value new_val) __attribute__((always_inline));
+
 /* The write barrier does not read or write the heap, it just
    modifies domain-local data structures. */
 static void write_barrier(value obj, int field, value old_val, value new_val)


### PR DESCRIPTION
This PR makes some optimizations to the `write_barrier` driven by benchmarking results on `chameneos_redux_lwt` in sandmark. 

It makes 3 changes:
 - inlines the write_barrier into the call sites in memory.c
 - use intnat for field indexes
 - match the branching logic in 4.06.1 `caml_modify` more closely

With these changes I see `chameneos_redux_lwt`:
 - 4.06.1: ~1.50s
 - multicore (baseline): ~2.00s
 - multicore (with this change): ~1.85s
