### PR TITLE
Unify sweep budget to be in word size units

### DIFF
--- a/byterun/custom.c
+++ b/byterun/custom.c
@@ -30,8 +30,7 @@ CAMLexport value caml_alloc_custom(const struct custom_operations * ops,
                                    mlsize_t max)
 {
   mlsize_t wosize;
-  CAMLparam0();
-  CAMLlocal1(result);
+  value result;
 
   wosize = 1 + (size + sizeof(value) - 1) / sizeof(value);
   if (wosize <= Max_young_wosize) {
@@ -59,7 +58,7 @@ CAMLexport value caml_alloc_custom(const struct custom_operations * ops,
     /* !!caml_adjust_gc_speed(mem,max); */
     result = caml_check_urgent_gc(result);
   }
-  CAMLreturn(result);
+  return result;
 }
 
 struct custom_operations_list {

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -347,6 +347,8 @@ static uintnat default_slice_budget() {
   p = (double) (saved_terminated_words + Caml_state->allocated_words) * 3.0 * (100 + caml_percent_free)
       / heap_words / caml_percent_free / 2.0;
 
+  if (p > 0.3) p = 0.3;
+
   computed_work = (intnat) (p * (heap_sweep_words + (heap_words * 100 / (100 + caml_percent_free))));
 
   /* adjust computed work for opportunistic_work done by this domain already */

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -354,7 +354,7 @@ static uintnat default_slice_budget() {
   /* adjust computed work for opportunistic_work done by this domain already */
   if ( Caml_state->opportunistic_work > computed_work ) {
     /* bound the credit that opportunistic_work can have vs computed_work */
-    if (Caml_state->opportunistic_work > computed_work*2) {
+    if (Caml_state->opportunistic_work > 2*computed_work) {
      Caml_state->opportunistic_work = 2*computed_work;
     }
 

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -324,9 +324,9 @@ static uintnat default_slice_budget() {
      Amount of marking work for the GC cycle:
                  MW = heap_words * 100 / (100 + caml_percent_free)
      Amount of sweeping work for the GC cycle:
-                 SW = heap_blocks
+                 SW = heap_sweep_words
      Amount of total work for the GC cycle:
-                 TW = MW + SW = heap_words * 100 / (100 + caml_percent_free) + heap_blocks
+                 TW = MW + SW = heap_words * 100 / (100 + caml_percent_free) + heap_sweep_words
 
      Amount of time to spend on this slice:
                  T = P * TT
@@ -337,7 +337,7 @@ static uintnat default_slice_budget() {
   */
   uintnat heap_size = caml_heap_size(Caml_state->shared_heap);
   heap_words = (double)Wsize_bsize(heap_size);
-  uintnat heap_blocks = caml_heap_blocks(Caml_state->shared_heap);
+  uintnat heap_sweep_words = heap_words;
 
   uintnat saved_terminated_words = terminated_domains_allocated_words;
   if( saved_terminated_words > 0 ) {
@@ -347,7 +347,7 @@ static uintnat default_slice_budget() {
   p = (double) (saved_terminated_words + Caml_state->allocated_words) * 3.0 * (100 + caml_percent_free)
       / heap_words / caml_percent_free / 2.0;
 
-  computed_work = (intnat) (p * (heap_blocks + (heap_words * 100 / (100 + caml_percent_free))));
+  computed_work = (intnat) (p * (heap_sweep_words + (heap_words * 100 / (100 + caml_percent_free))));
 
   /* adjust computed work for opportunistic_work done by this domain already */
   if ( Caml_state->opportunistic_work > computed_work ) {

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1202,8 +1202,13 @@ mark_again:
               (unsigned long)(domain_state->stat_blocks_marked - blocks_marked_before));
   domain_state->stat_major_words += domain_state->allocated_words;
   domain_state->allocated_words = 0;
-  if (opportunistic)
-  domain_state->opportunistic_work += computed_work - budget;
+  if (opportunistic) {
+    domain_state->opportunistic_work += computed_work - budget;
+  } else {
+    if (budget < 0)
+      domain_state->opportunistic_work += -budget;
+  }
+
 
   if (!opportunistic && is_complete_phase_sweep_ephe(d)) {
     saved_major_cycle = caml_major_cycles_completed;

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -713,9 +713,12 @@ CAMLexport void caml_minor_collection (void)
 
 CAMLexport value caml_check_urgent_gc (value extra_root)
 {
-  CAMLparam1 (extra_root);
-  caml_handle_gc_interrupt();
-  CAMLreturn (extra_root);
+  if (Caml_check_gc_interrupt(Caml_state)) {
+    CAMLparam1(extra_root);
+    caml_handle_gc_interrupt();
+    CAMLdrop;
+  }
+  return extra_root;
 }
 
 static void realloc_generic_table

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -218,11 +218,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
     domain_state->opportunistic_work +=
       pool_sweep(local, &local->unswept_avail_pools[sz], sz);
   }
-  while (!local->avail_pools[sz] && local->unswept_full_pools[sz]) {
-    caml_domain_state* domain_state = caml_domain_self()->state;
-    domain_state->opportunistic_work +=
-      pool_sweep(local, &local->unswept_full_pools[sz], sz);
-  }
+
   r = local->avail_pools[sz];
   if (r) return r;
 

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -425,7 +425,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist, sizeclass 
       all_free = 0;
     }
     p += wh;
-    work++;
+    work += wh;
   }
 
   if (all_free) {

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -206,20 +206,27 @@ static intnat pool_sweep(struct caml_heap_state* local, pool**, sizeclass sz);
 static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
   pool* r;
   pool* v;
+  int moved_pools;
 
   /* Hopefully we have a pool we can use directly */
   r = local->avail_pools[sz];
   if (r) return r;
 
   /* Otherwise, try to sweep until we find one */
-  while (!local->avail_pools[sz] &&
-         pool_sweep(local, &local->unswept_avail_pools[sz], sz));
-  while (!local->avail_pools[sz] &&
-         pool_sweep(local, &local->unswept_full_pools[sz], sz));
+  while (!local->avail_pools[sz] && local->unswept_avail_pools[sz]) {
+    caml_domain_state* domain_state = caml_domain_self()->state;
+    domain_state->opportunistic_work +=
+      pool_sweep(local, &local->unswept_avail_pools[sz], sz);
+  }
+  while (!local->avail_pools[sz] && local->unswept_full_pools[sz]) {
+    caml_domain_state* domain_state = caml_domain_self()->state;
+    domain_state->opportunistic_work +=
+      pool_sweep(local, &local->unswept_full_pools[sz], sz);
+  }
   r = local->avail_pools[sz];
   if (r) return r;
 
-/* Haven't managed to find a pool locally, try the global ones */
+  /* Haven't managed to find a pool locally, try the global ones */
   caml_plat_lock(&pool_freelist.lock);
   if( pool_freelist.global_avail_pools[sz] ) {
     r = pool_freelist.global_avail_pools[sz];
@@ -262,7 +269,7 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
     caml_accum_heap_stats(&local->stats, &tmp_stats);
     caml_remove_heap_stats(&pool_freelist.stats, &tmp_stats);
 
-    int moved_pools = move_all_pools(&pool_freelist.global_full_pools[sz], &local->full_pools[sz], local->owner);
+    moved_pools = move_all_pools(&pool_freelist.global_full_pools[sz], &local->full_pools[sz], local->owner);
 
     if (local->stats.pool_words > local->stats.pool_max_words)
       local->stats.pool_max_words = local->stats.pool_words;
@@ -270,8 +277,10 @@ static pool* pool_find(struct caml_heap_state* local, sizeclass sz) {
 
   caml_plat_unlock(&pool_freelist.lock);
 
-  if( !r ) {
-    pool_sweep(local, &local->full_pools[sz], sz);
+  if( !r && moved_pools ) {
+    caml_domain_state* domain_state = caml_domain_self()->state;
+    domain_state->opportunistic_work +=
+      pool_sweep(local, &local->full_pools[sz], sz);
     r = local->avail_pools[sz];
   }
 
@@ -464,12 +473,17 @@ intnat caml_sweep(struct caml_heap_state* local, intnat work) {
   /* Sweep local pools */
   while (work > 0 && local->next_to_sweep < NUM_SIZECLASSES) {
     sizeclass sz = local->next_to_sweep;
-    intnat sweep_work =
-      pool_sweep(local, &local->unswept_avail_pools[sz], sz) +
-      pool_sweep(local, &local->unswept_full_pools[sz], sz);
-    if (sweep_work) {
-      work -= sweep_work;
-    } else {
+    intnat full_sweep_work = 0;
+    intnat avail_sweep_work =
+      pool_sweep(local, &local->unswept_avail_pools[sz], sz);
+    work -= avail_sweep_work;
+
+    if (work > 0) {
+      full_sweep_work = pool_sweep(local, &local->unswept_full_pools[sz], sz);
+      work -= full_sweep_work;
+    }
+
+    if(full_sweep_work+avail_sweep_work == 0) {
       local->next_to_sweep++;
     }
   }


### PR DESCRIPTION
This PR alters the accounting for sweep work to be all in word size. At present there appears to be a discrepancy between large alloc and pool sweep work:
- The budget is setup here in blocks: https://github.com/ocaml-multicore/ocaml-multicore/blob/master/byterun/major_gc.c#L340
- The sweep work for pools is in blocks: https://github.com/ocaml-multicore/ocaml-multicore/blob/master/byterun/shared_heap.c#L428
- The sweep work for large allocs is in word size: https://github.com/ocaml-multicore/ocaml-multicore/blob/master/byterun/shared_heap.c#L458
