### PR TITLE
Always update budget_left in major_collection_slice

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1060,7 +1060,10 @@ static intnat major_collection_slice(intnat howmuch,
   /* shortcut out if there is no opportunistic work to be done
    * NB: needed particularly to avoid caml_ev spam when polling */
   if (opportunistic && domain_state->sweeping_done && domain_state->marking_done)
+  {
+    if (budget_left) *budget_left = budget;
     return computed_work;
+  }
 
   caml_ev_begin("major_gc/slice");
 


### PR DESCRIPTION
Minor fix to make sure budget_left is updated with opportunistic slices. 
Prevents busy spinning when no work to do, for example when called from: https://github.com/ocaml-multicore/ocaml-multicore/blob/master/byterun/domain.c#L1037

(fix by @stedolan for stw ported here)