### PR TITLE
Make Chunk_size for opportunistic mark work 

### DIFF
--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -1014,7 +1014,7 @@ CAMLprim value caml_ml_domain_critical_section(value delta)
   return Val_unit;
 }
 
-#define Chunk_size 0x10000
+#define Chunk_size 0x400
 
 CAMLprim value caml_ml_domain_yield(value unused)
 {


### PR DESCRIPTION
This PR changes the Chunk size for opportunistic mark work in the domain yield functions to be 0x400 (1024) rather than 0x10000 (65536).