### PR TITLE
Account correctly for incremental mark budget

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -564,6 +564,7 @@ static intnat do_some_marking(struct mark_stack* stk, intnat budget) {
       mark_stack_push(stk, e);
       break;
     }
+    budget--;
     CAMLassert(Is_markable(e.block) &&
                Has_status_hd(Hd_val(e.block), global.MARKED) &&
                Tag_val(e.block) < No_scan_tag &&
@@ -581,8 +582,9 @@ static intnat do_some_marking(struct mark_stack* stk, intnat budget) {
         if (Tag_hd(hd) == Cont_tag) {
           mark_stack_push(stk, e);
           caml_darken_cont(v);
-	  e = (mark_entry){0};
-	} else {
+          e = (mark_entry){0};
+          budget -= Whsize_hd(hd);
+        } else {
 again:
           if (Tag_hd(hd) == Lazy_tag || Tag_hd(hd) == Forcing_tag) {
             if (!atomic_compare_exchange_strong(
@@ -605,7 +607,6 @@ again:
           }
         }
       }
-      budget -= Whsize_hd(hd);
     }
   }
   return budget;


### PR DESCRIPTION
We used to incorrectly count the cost for every field of the object to be the size of the object (`      budget -= Whsize_hd(hd);` was in the body of the while loop which iterates over each field`). This PR fixes the behavior. This PR improves the max latency of menhir.ocamly from 634 ms to 526 ms. 