### PR TITLE
Check interrupts during caml_empty_mark_stack and caml_finish_sweeping

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1272,8 +1272,10 @@ void caml_finish_major_cycle ()
 }
 
 void caml_empty_mark_stack () {
-  while (!Caml_state->marking_done)
-    mark(10000000);
+  while (!Caml_state->marking_done){
+    mark(1000);
+    caml_handle_incoming_interrupts();
+  }
 
   if (Caml_state->stat_blocks_marked)
     caml_gc_log("Finished marking major heap. Marked %u blocks",
@@ -1292,13 +1294,19 @@ void caml_finish_marking () {
 }
 
 void caml_finish_sweeping () {
-  if (!Caml_state->sweeping_done) {
-    caml_ev_begin("major_gc/finish_sweeping");
-    while (caml_sweep(Caml_state->shared_heap, 10) <= 0);
-    Caml_state->sweeping_done = 1;
-    atomic_fetch_add_verify_ge0(&num_domains_to_sweep, -1);
-    caml_ev_end("major_gc/finish_sweeping");
+  if (Caml_state->sweeping_done) return;
+  caml_ev_begin("major_gc/finish_sweeping");
+  while (!Caml_state->sweeping_done) {
+    if (caml_sweep(Caml_state->shared_heap, 10) > 0) {
+      /* just finished sweeping */
+      CAMLassert(Caml_state->sweeping_done == 0);
+      Caml_state->sweeping_done = 1;
+      atomic_fetch_add_verify_ge0(&num_domains_to_sweep, -1);
+      break;
+    }
+    caml_handle_incoming_interrupts();
   }
+  caml_ev_end("major_gc/finish_sweeping");
 }
 
 static struct pool* find_pool_to_rescan()


### PR DESCRIPTION
This PR checks interrupts during `caml_empty_mark_stack` and `caml_finish_sweeping` which can improve pause times when main domains are running. 

It mirrors: https://github.com/ctk21/ocaml-multicore/pull/43
And is a second attempt after the bad #300 
