### PR TITLE
Absolute exception stack

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -947,11 +947,9 @@ let emit_instr fallthrough i =
       cfi_adjust_cfa_offset 8;
       I.push (domain_field Domainstate.Domain_exn_handler);
       cfi_adjust_cfa_offset 8;
-      I.sub rsp (mem64 NONE 0 RSP);
       I.mov rsp (domain_field Domainstate.Domain_exn_handler);
       stack_offset := !stack_offset + 16
   | Lpoptrap ->
-      I.add rsp (mem64 NONE 0 RSP);
       I.pop (domain_field Domainstate.Domain_exn_handler);
       cfi_adjust_cfa_offset (-8);
       I.add (int 8) rsp;
@@ -970,7 +968,6 @@ let emit_instr fallthrough i =
           record_frame Reg.Set.empty true i.dbg
       | Lambda.Raise_notrace ->
           I.mov (domain_field Domainstate.Domain_exn_handler) rsp;
-          I.add rsp (mem64 NONE 0 RSP);
           I.pop (domain_field Domainstate.Domain_exn_handler);
           I.ret ()
       end

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -878,7 +878,10 @@ CFI_STARTPROC
         subq    $16, %r11
         leaq    LBL(fiber_exn_handler)(%rip), %r10
         movq    %r10, 8(%r11)
-        movq    $0, 0(%r11) /* dummy previous trap frame */
+    /* load the previous context exn_handler so that copying stacks works */
+        movq    Caml_state(current_stack), %r10
+        movq    (%r10), %r10
+        movq    %r10, 0(%r11)
         movq    %r11, Caml_state(exn_handler)
     /* Switch to the new stack */
         movq    %r11, %rsp

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -113,17 +113,15 @@
         leaq    G(label)(%rip), dst
 #endif
 
-/* Push the current exception handler.
-   (Stored as an offset, to survive stack reallocations). Clobbers %r11 */
+/* Push the current exception handler. Clobbers %r11 */
 #define PUSH_EXN_HANDLER \
         movq    Caml_state(exn_handler), %r11; \
         pushq   %r11; CFI_ADJUST(8);
 
-/* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers %r11 and %r10. */
+/* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers %r11 */
 #define POP_EXN_HANDLER \
         leaq    Caml_state(exn_handler), %r11; \
-        popq    %r10; CFI_ADJUST(-8); \
-        movq    %r10, (%r11)
+        popq    (%r11); CFI_ADJUST(-8);
 
 /******************************************************************************/
 /* Stack switching operations */
@@ -649,13 +647,14 @@ LBL(caml_start_program):
     /* Load the OCaml stack. */
         movq    Caml_state(current_stack), %r11
         movq    Stack_sp(%r11), %r10
-    /* Build a handler for exceptions raised in OCaml on the OCaml stack.
-       There is no previous exception handler. Instead, we use the prev
-       slot to store the C stack pointer, to allow DWARF backtraces */
+    /* Build a handler for exceptions raised in OCaml on the OCaml stack. */
         subq    $16, %r10
         lea     LBL(109)(%rip), %r11
         movq    %r11, 8(%r10)
-        movq    %rsp, 0(%r10)
+    /* load the previous context exn_handler so that copying stacks works */
+        movq    Caml_state(current_stack), %r11
+        movq    (%r11), %r11
+        movq    %r11, 0(%r10)
         movq    %r10, Caml_state(exn_handler)
     /* Switch stacks and call the OCaml code */
         movq    %r10, %rsp
@@ -666,7 +665,10 @@ LBL(caml_start_program):
              24 /* struct c_stack_link */ + 6*8 /* callee save regs */ + 8 /* ret addr */
         call    *%r12
 LBL(108):
-        leaq    16(%rsp), %r10 /* pop exn handler */
+    /* pop exn handler */
+        movq    0(%rsp), %r11
+        movq    %r11, Caml_state(exn_handler)
+        leaq    16(%rsp), %r10
 1:  /* Update alloc ptr */
         movq    %r15, Caml_state(young_ptr)
     /* Return to C stack. */

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -117,16 +117,12 @@
    (Stored as an offset, to survive stack reallocations). Clobbers %r11 */
 #define PUSH_EXN_HANDLER \
         movq    Caml_state(exn_handler), %r11; \
-        subq    %rsp, %r11; \
-        addq    $0x8, %r11; \
         pushq   %r11; CFI_ADJUST(8);
 
 /* Pop the current exception handler. Undoes PUSH_EXN_HANDLER. Clobbers %r11 and %r10. */
 #define POP_EXN_HANDLER \
         leaq    Caml_state(exn_handler), %r11; \
         popq    %r10; CFI_ADJUST(-8); \
-        subq    $0x8, %r10; \
-        addq    %rsp, %r10; \
         movq    %r10, (%r11)
 
 /******************************************************************************/

--- a/byterun/fiber.c
+++ b/byterun/fiber.c
@@ -238,14 +238,22 @@ void caml_scan_stack(scanning_action f, void* fdata, struct stack_info* stack)
 /* Update absolute exception pointers for new stack*/
 static void rewrite_exception_stack(struct stack_info *old_stack, value* exn_ptr, struct stack_info *new_stack)
 {
+  caml_gc_log ("Old [%lu, %lu]", Stack_base(old_stack), Stack_high(old_stack));
+  caml_gc_log ("New [%lu, %lu]", Stack_base(new_stack), Stack_high(new_stack));
+  caml_gc_log ("exn_ptr=%lu", *exn_ptr);
+
   while (Stack_base(old_stack) < *exn_ptr && *exn_ptr <= Stack_high(old_stack)) {
+    value old_val = *exn_ptr;
     *exn_ptr = Stack_high(new_stack) - (Stack_high(old_stack) - (value*)*exn_ptr);
+
+    caml_gc_log ("Rewriting %lu to %lu", old_val, *exn_ptr);
 
     CAMLassert(Stack_base(new_stack) < (value*)*exn_ptr);
     CAMLassert((value*)*exn_ptr <= Stack_high(new_stack));
 
     exn_ptr = (char*)*exn_ptr;
   }
+  caml_gc_log ("finished with exn_ptr=%lu", *exn_ptr);
 }
 
 int caml_try_realloc_stack(asize_t required_space)


### PR DESCRIPTION
This PR moves the representation of the exception stack from relative addressing to absolute addressing. 

This was prompted by benchmark analysis showing the exception push/pop for multicore can be expensive. For example the following code can have much more expensive exception handling overhead:
```ocaml
let get g x y =
  try g.(x).(y)
  with _ -> 0
```

The code is a bit fiddly as we need to:
 - rewrite the exception stack when stacks are copied in `fiber.c`
 - update the assembler to allow the stack to be visible through `ocaml stack` -> `c stack` -> `ocaml stack` calls (e.g. `callback/test4.ml`)
 - correctly handle the cloning of continuations in `fiber.c`

The testsuite passes with these changes, but I'm open to more test cases if people have concerns. 

Sandmark serial benchmark results that I got with this change:
<img width="988" alt="Screenshot 2020-03-09 at 14 59 15" src="https://user-images.githubusercontent.com/1682628/76410587-165b3680-6388-11ea-95fc-20213c363479.png">
