### PR TITLE
Fix bug with Weak.blit

### DIFF
--- a/byterun/caml/weak.h
+++ b/byterun/caml/weak.h
@@ -23,8 +23,13 @@
 extern value caml_ephe_none;
 
 struct caml_ephe_info {
-  value todo;
-  value live;
+  value todo; /* These are ephemerons which need to be marked and swept in the
+                 current cycle. If the ephemeron is alive, after marking, they
+                 go into the live list. */
+  value live; /* These are ephemerons which are alive in the current cycle.
+                 They still need to be swept to get rid of dead keys and
+                 values. Invariant: No keys are unreachable for these
+                 ephemerons. */
   uintnat cycle;
   struct {
     value* todop;

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -356,8 +356,8 @@ static value ephe_blit_field_produce_domain (value es, value ofs, value len,
   CAMLassert (Ephe_domain(es) == d);
 
   for (i = 0; i < length; i++) {
-    Op_val(es)[offset_s + i] = caml_promote(d, Op_val(es)[offset_s + i]);
     caml_darken(0, Op_val(es)[offset_s + i], 0);
+    Op_val(es)[offset_s + i] = caml_promote(d, Op_val(es)[offset_s + i]);
   }
   ar = caml_alloc_shr (length, 0);
   for (i = 0; i < length; i++) {
@@ -701,10 +701,12 @@ static value ephe_blit_field (value es, mlsize_t offset_s,
     if (my_domain == d1 && my_domain == d2) {
       if (offset_d < offset_s) {
         for (i = 0; i < length; i++) {
+          caml_darken(0, Op_val(es)[offset_s + i], 0);
           do_set(my_domain, ed, offset_d + i, Op_val(es)[offset_s + i]);
         }
       } else {
         for (i = length - 1; i >= 0; i--) {
+          caml_darken(0, Op_val(es)[offset_s + i], 0);
           do_set(my_domain, ed, offset_d + i, Op_val(es)[offset_s + i]);
         }
       }


### PR DESCRIPTION
Multicore assumes that newly allocated ephemerons need not be marked or flushed in the cycle that they were allocated. The ephemerons themselves are allocated Marked. But can the keys or data be unmarked? Yes they can. `blit` operations copy weak references from one ephemeron to another without marking them. If the keys, for example, remain unmarked at the end of the marking phase, then the newly allocated ephemeron should sweep those keys to get rid of them in the same phase.

The fix is to mark the keys that are being blited. This will keep the unreachable keys alive for one more major cycle. Alternatively, we could have swept the newly allocated ephemerons in the cycle in which they were allocated. But this introduces a race between ephemeron sweeping and mutator allocating new ephemerons. This is not a hard problem but a tedious one to solve -- this makes `num_domains_to_sweep_ephe` not monotonically reduce to 0 and we need other mechanisms to get the synchronization right. 

If keeping the unreachable keys around for one more cycle causes performance problems, then we can revisit this issue. 