### PR TITLE
move num_domains_running decrement

### DIFF
--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -1037,7 +1037,6 @@ static void domain_terminate()
       finished = 1;
       s->terminating = 0;
       s->running = 0;
-      atomic_fetch_add(&num_domains_running, -1);
       s->unique_id += Max_domains;
     }
     caml_plat_unlock(&s->lock);
@@ -1063,6 +1062,7 @@ static void domain_terminate()
   }
   caml_plat_unlock(&domain_self->roots_lock);
   caml_plat_assert_all_locks_unlocked();
+  atomic_fetch_add(&num_domains_running, -1);
 }
 
 void caml_handle_incoming_interrupts()

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -1062,6 +1062,9 @@ static void domain_terminate()
   }
   caml_plat_unlock(&domain_self->roots_lock);
   caml_plat_assert_all_locks_unlocked();
+  /* This is the last thing we do because we need to be able to rely
+     on caml_domain_alone (which uses num_domains_running) in at least
+     the shared_heap lockfree fast paths */
   atomic_fetch_add(&num_domains_running, -1);
 }
 


### PR DESCRIPTION
Moving the `num_domains_running` decrement allows us to rely on `caml_domain_alone()` in the shared heap teardown. This means we can add fast-paths for the single domain case in the new lockfree pools code that's incoming.