### PR TITLE
Added eventlog_to_latencies.py to tools

### DIFF
--- a/tools/eventlog_to_latencies.py
+++ b/tools/eventlog_to_latencies.py
@@ -1,0 +1,107 @@
+from intervaltree import IntervalTree, Interval
+import sys
+import subprocess
+import json
+import os
+
+if len(sys.argv) < 2:
+  print ("Usage: %s EVENTLOG\n" % sys.argv[0])
+  print ("Generate GC latency distribution report from eventlog")
+  sys.exit(1)
+
+json_file = sys.argv[1]
+
+percentages = [10,20,30,40,50,60,70,80,90,95,99,99.9]
+
+def distribution(l):
+  to_indices = []
+  for p in percentages:
+    i = int(round(float(len(l))*float(p)/100.0-1,0))
+    to_indices.append(i)
+  i = 0
+  distr = []
+  while (i < len(percentages)):
+    if (to_indices[i] == -1):
+      distr.append(0)
+    else:
+      distr.append(l[to_indices[i]])
+    i+=1
+
+  return distr
+
+def main():
+  trees = {}
+  with open(json_file) as f:
+    data = json.load(f)
+    stacks = {}
+    for event in data["traceEvents"]:
+      if (event["ph"] == "B"):
+        key = str(event["pid"])+":"+str(event["tid"])
+        ts = int(float(event["ts"])*1000.0)
+        name = event["name"]
+        if key in stacks:
+          stacks[key].append((name,ts,0))
+        else:
+          stacks[key] = [(name,ts,0)]
+      elif (event["ph"] == "E"):
+        key = str(event["pid"])+":"+str(event["tid"])
+        ts = int(float(event["ts"])*1000.0)
+        name = event["name"]
+        (nameStart, startTs, overhead) = stacks[key].pop()
+        assert (nameStart == name)
+        if not key in trees:
+          trees[key] = IntervalTree()
+        trees[key].addi(startTs, ts, {'name': name, 'overhead': overhead, 'tid': event["tid"]})
+      elif (event["ph"] == "C" and event["name"] == "overhead#"):
+        key = str(event["pid"])+":"+str(event["tid"])
+        overhead = int(event["args"]["value"])
+        l = []
+        for e in stacks[key]:
+          (name,ts,o) = e
+          l.append((name,ts,o+overhead))
+        stacks[key] = l
+
+  latencies = []
+  intervals = []
+
+  for t in trees.values():
+    domain_terminate_intervals = IntervalTree((i for i in t if i.data['name'].startswith("major_gc/finish_")))
+    t.merge_overlaps((lambda acc,v: {'name': acc['name'], 'overhead': acc['overhead'] + v['overhead'], 'tid': acc['tid']}))
+    latencies = latencies + list(map(lambda x: x.end - x.begin - x.data['overhead'], sorted(t - domain_terminate_intervals)))
+    intervals.extend(t)
+  sorted_latencies = sorted(latencies)
+
+  if (len(sorted_latencies) > 0):
+    max_latency = sorted_latencies[len(sorted_latencies) - 1]
+    avg_latency = sum(sorted_latencies)/len(sorted_latencies)
+  else:
+    max_latency = 0
+    avg_latency = 0
+
+  distr = distribution(sorted_latencies)
+
+  out = {}
+  print ("Mean latency = " + str(avg_latency) + " ns")
+  print ("Max latency = " + str(max_latency) + " ns")
+  print ("")
+  print ("## Latency distribution")
+  print ("")
+  print ("Percentile, Latency(ns)")
+  for (p,l) in zip(percentages,distr):
+    print(str(p) + "," + str(l))
+
+  sorted_intervals = sorted(intervals, key=lambda i: -(i.end - i.begin))
+
+  print ("")
+  print ("## Top slowest events")
+  print ("")
+  print ("Latency(ns), Start Timestamp(ns), End TimeStamp(ns), Event, Overhead, Domain ID")
+  for interval in sorted_intervals[0:32]:
+    print(str(interval.end - interval.begin) + ", " +
+          str(interval.begin) + ", " +
+          str(interval.end) + ", " +
+          interval.data['name'] + ", " +
+          str(interval.data['overhead']) + ", " +
+          str(interval.data['tid']))
+
+main()


### PR DESCRIPTION
A script to generate GC latency report from eventlog. Here's an example:

```bash
$ python3 eventlog_to_latencies.py ~/temp/eventlog.16343.json                                                                      [14/779]
Mean latency = 1210944.3816942552 ns            
Max latency = 28443132 ns                     
                                              
## Latency distribution                     
                                                
Percentile, Latency(ns)                         
10,1643                                       
20,2848                                         
30,5910                                         
40,12347                                        
50,30388                                        
60,113719                                     
70,457042                                     
80,2336664                                      
90,4018943                              
95,5422204
99,14504274
99.9,20195588

## Top slowest events

Latency(ns), Start Timestamp(ns), End TimeStamp(ns), Event, Overhead, Domain ID
28443132, 1312830812, 1341273944, dispatch, 0, 1
23778085, 1385542973, 1409321058, dispatch, 0, 2
20195588, 1342129886, 1362325474, dispatch, 0, 3
18709327, 1435010657, 1453719984, dispatch, 0, 0
18578143, 1416014367, 1434592510, dispatch, 0, 0
18139757, 968702138, 986841895, dispatch, 0, 2
18128834, 889954670, 908083504, dispatch, 0, 1
17261640, 1188683917, 1205945557, dispatch, 0, 2
17245697, 1334845335, 1352091032, dispatch, 0, 0
17068681, 1193480554, 1210549235, dispatch, 0, 1
17034160, 947883766, 964917926, dispatch, 0, 2
16978896, 1398624844, 1415603740, dispatch, 0, 0
16335988, 1258782416, 1275118404, dispatch, 0, 3
16171970, 1116411841, 1132583811, dispatch, 0, 0
15831116, 1045093930, 1060925046, dispatch, 0, 0
15761682, 1197650205, 1213411887, dispatch, 0, 3
15656797, 1331356242, 1347013039, dispatch, 0, 2
15182185, 236555597, 251737782, dispatch, 0, 0
15149261, 1275492750, 1290642011, dispatch, 0, 3
15009776, 221210973, 236220749, dispatch, 0, 0
14741857, 153826672, 168568529, dispatch, 0, 0
14504274, 77495456, 91999730, dispatch, 0, 0
14489572, 1327114211, 1341603783, dispatch, 0, 3
14176135, 1244239362, 1258415497, dispatch, 0, 3
14163619, 139328021, 153491640, dispatch, 0, 0
13651899, 1196414247, 1210066146, dispatch, 0, 0
13548830, 1359025248, 1372574078, dispatch, 0, 2
13498473, 1317323065, 1330821538, dispatch, 0, 2
13394272, 1031303642, 1044697914, dispatch, 0, 0
13133592, 112719695, 125853287, dispatch, 0, 0
12793435, 208082311, 220875746, dispatch, 0, 0
12665612, 1313775672, 1326441284, dispatch, 0, 3
```

The starting timestamp can be used to identify the event in `chrome://tracing` loaded with the eventlog file. 

![image](https://user-images.githubusercontent.com/410484/78642975-2efc3500-78d1-11ea-8632-d65e768e998e.png)
