### PR TITLE
Get multicore compiler working with flambda.

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -1013,25 +1013,6 @@ let rec close fenv cenv = function
       let dbg = Debuginfo.from_location loc in
       (Uprim(Praise k, [ulam], dbg),
        Value_unknown)
-  | Lprim(Pperform, [arg], loc) ->
-      let (arg, _approx) = close fenv cenv arg in
-      let dbg = Debuginfo.from_location loc in
-      let alloc_cont = Uprim(Pmakeblock(Obj.cont_tag, Mutable, None),
-                             [Uconst (Uconst_int 0)],
-                             dbg) in
-      (Udirect_apply ("caml_perform", [arg; alloc_cont], dbg), Value_unknown)
-  | Lprim(Presume, args, loc) ->
-      let args = close_list fenv cenv args in
-      let dbg = Debuginfo.from_location loc in
-      (Udirect_apply ("caml_resume", args, dbg), Value_unknown)
-  | Lprim(Prunstack, args, loc) ->
-      let args = close_list fenv cenv args in
-      let dbg = Debuginfo.from_location loc in
-      (Udirect_apply ("caml_runstack", args, dbg), Value_unknown)
-  | Lprim(Preperform, args, loc) ->
-      let args = close_list fenv cenv args in
-      let dbg = Debuginfo.from_location loc in
-      (Udirect_apply ("caml_reperform", args, dbg), Value_unknown)
   | Lprim(p, args, loc) ->
       let dbg = Debuginfo.from_location loc in
       simplif_prim !Clflags.float_const_prop

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2004,6 +2004,10 @@ and transl_prim_1 env p arg dbg =
       Cop(Craise (Lambda.Raise_reraise), [transl env arg], dbg)
   | Praise Lambda.Raise_regular ->
       raise_regular dbg (transl env arg)
+  | Pperform ->
+      let cont = make_alloc dbg Obj.cont_tag [int_const 0] in
+      Cop(Capply typ_val, [Cconst_symbol "caml_perform"; transl env arg; cont],
+          dbg)
   (* Integer operations *)
   | Pnegint ->
       Cop(Csubi, [Cconst_int 2; transl env arg], dbg)
@@ -2589,6 +2593,21 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
   | Patomic_cas ->
      Cop (Cextcall ("caml_atomic_cas", typ_int, false, None),
           [transl env arg1; transl env arg2; transl env arg3], dbg)
+
+  | Presume ->
+      Cop (Capply typ_val, [Cconst_symbol "caml_resume"; transl env arg1;
+                            transl env arg2; transl env arg3],
+           dbg)
+
+  | Prunstack ->
+      Cop (Capply typ_val, [Cconst_symbol "caml_runstack"; transl env arg1;
+                            transl env arg2; transl env arg3],
+           dbg)
+
+  | Preperform ->
+      Cop (Capply typ_val, [Cconst_symbol "caml_reperform"; transl env arg1;
+                            transl env arg2; transl env arg3],
+           dbg)
 
   | prim ->
       fatal_errorf "Cmmgen.transl_prim_3: %a" Printlambda.primitive prim


### PR DESCRIPTION
Effect handler primitives were translated to C calls in lambda to
Clambda conversion (`asmcomp/closure.ml`). Since flambda does not go
through this translation phase, the effect handler primitives were kept
around and the compilation fails at cmmgen where the cmmgen pass
observes an unexpected primitive.

The fix is to do the translation at cmmgen rather than the lambda to
clambda conversion.