### PR TITLE
Add a missing case for handling lazy values in matching.ml

### DIFF
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1522,7 +1522,16 @@ let inline_lazy_force_switch arg loc =
                sw_blocks =
                  [ (Obj.forward_tag, Lprim(Pfield(0, Pointer, Mutable),
                                            [varg], loc));
+
                    (Obj.lazy_tag,
+                    Lapply{ap_should_be_tailcall=false;
+                           ap_loc=loc;
+                           ap_func=force_fun;
+                           ap_args=[varg];
+                           ap_inlined=Default_inline;
+                           ap_specialised=Default_specialise});
+
+                   (Obj.forcing_tag,
                     Lapply{ap_should_be_tailcall=false;
                            ap_loc=loc;
                            ap_func=force_fun;


### PR DESCRIPTION
Add the missing case for `forcing_tag`.